### PR TITLE
feat: Update OG title and description from pagedata

### DIFF
--- a/.vitepress/shared.mts
+++ b/.vitepress/shared.mts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitepress";
+import { defineConfig, HeadConfig } from "vitepress";
 import { search as koSearch } from "./ko.mts";
 
 export const shared = defineConfig({
@@ -27,6 +27,15 @@ export const shared = defineConfig({
       }
     ]
   ],
+
+  transformHead: ({ pageData }) => {
+    const head: HeadConfig[] = []
+
+    head.push(['meta', { property: 'og:title', content: pageData.frontmatter.title }])
+    head.push(['meta', { property: 'og:description', content: pageData.frontmatter.description }])
+
+    return head
+  },
 
   themeConfig: {
     logo: "/images/ff-symbol.svg",

--- a/.vitepress/shared.mts
+++ b/.vitepress/shared.mts
@@ -29,12 +29,14 @@ export const shared = defineConfig({
   ],
 
   transformHead: ({ pageData }) => {
-    const head: HeadConfig[] = []
+    const head: HeadConfig[] = [];
+    const title = pageData.frontmatter.title || 'Frontend Fundamentals';
+    const description = pageData.frontmatter.description || 'Guidelines for easily modifiable frontend code';
 
-    head.push(['meta', { property: 'og:title', content: pageData.frontmatter.title }])
-    head.push(['meta', { property: 'og:description', content: pageData.frontmatter.description }])
+    head.push(['meta', { property: 'og:title', content: title }]);
+    head.push(['meta', { property: 'og:description', content: description }]);
 
-    return head
+    return head;
   },
 
   themeConfig: {


### PR DESCRIPTION
<img width="513" alt="image" src="https://github.com/user-attachments/assets/1f0f7c28-10d6-4460-bd32-42e4acaee4e2" />
<img width="942" alt="image" src="https://github.com/user-attachments/assets/04845e45-1668-4a3c-9eb3-567ae4b5319e" />
<img width="286" alt="image" src="https://github.com/user-attachments/assets/fa45a239-8269-433d-97c4-b68d4f93f2bd" />


Since there are only title and description in the meta data, 
Kakaotalk does not render description on the sharing card.

Push meta data from pageData