### PR TITLE
feat: Update default og title, description

### DIFF
--- a/.vitepress/shared.mts
+++ b/.vitepress/shared.mts
@@ -30,8 +30,8 @@ export const shared = defineConfig({
 
   transformHead: ({ pageData }) => {
     const head: HeadConfig[] = [];
-    const title = pageData.frontmatter.title || 'Frontend Fundamentals';
-    const description = pageData.frontmatter.description || 'Guidelines for easily modifiable frontend code';
+    const title = pageData.frontmatter.title || pageData.title || 'Frontend Fundamentals';
+    const description = pageData.frontmatter.description || pageData.description || 'Guidelines for easily modifiable frontend code';
 
     head.push(['meta', { property: 'og:title', content: title }]);
     head.push(['meta', { property: 'og:description', content: description }]);


### PR DESCRIPTION
<img width="861" alt="image" src="https://github.com/user-attachments/assets/dbc6aca2-4ffd-4ba9-99f4-76c12489a5f4" />

Since we don't give title, description with frontmatter format in our document, 
The og title, descriptions need to be updated from page title, description.