### PR TITLE
fix: correct-spacing

### DIFF
--- a/code/examples/ternary-operator.md
+++ b/code/examples/ternary-operator.md
@@ -11,7 +11,7 @@
 다음 코드는 `A조건`과 `B조건`에 따라서 `'BOTH'`, `'A'`, 또는 `'NONE'` 중 하나를 `status`에 지정하는 코드예요.
 
 ```typescript
-const status = A조건 && B조건 ? "BOTH" : 둘다아닌경우 ? "NONE" : A조건 ? "A" : undefined;
+const status = A조건 && B조건 ? "BOTH" : 둘 다 아닌 경우 ? "NONE" : A조건 ? "A" : undefined;
 ```
 
 ## 👃 코드 냄새 맡아보기


### PR DESCRIPTION
[복잡한 삼항 연산자를 풀어서 쓰기](https://frontend-fundamentals.com/code/examples/ternary-operator.html) 페이지 띄어쓰기 수정입니다.
둘다아닌경우 -> 둘 다 아닌 경우