### PR TITLE
fix: fix codeblock language identifier

### DIFF
--- a/code/examples/user-policy.md
+++ b/code/examples/user-policy.md
@@ -16,7 +16,7 @@
 - 사용자의 권한이 관리자(Admin)라면, `Invite`와 `View` 버튼을 보여줘요.
 - 사용자의 권한이 보기 전용(Viewer)라면, `Invite` 버튼은 비활성화하고, `View` 버튼을 보여줘요.
 
-```typescript
+```tsx
 function Page() {
   const user = useUser();
   const policy = getPolicyByRole(user.role);
@@ -60,7 +60,7 @@ const POLICY_SET = {
 권한에 따른 조건을 요구사항 그대로 코드에 드러내는 방법이에요. 이렇게 하면 `Invite` 버튼이 비활성화되는 때를 코드에서 바로 확인할 수 있어요. 
 코드를 위에서 아래로만 읽으면 한눈에 권한을 다루는 로직을 파악할 수 있어요.
 
-```typescript
+```tsx
 function Page() {
   const user = useUser();
 

--- a/en/code/examples/user-policy.md
+++ b/en/code/examples/user-policy.md
@@ -16,7 +16,7 @@ The following code displays buttons differently based on the user's permission.
 - If the user's permission is Administrator (Admin), it displays both `Invite` and `View` buttons.
 - If the user's permission is Viewer, it disables the `Invite` button and displays the `View` button.
 
-```typescript
+```tsx
 function Page() {
   const user = useUser();
   const policy = getPolicyByRole(user.role);
@@ -60,7 +60,7 @@ Using abstractions like `POLICY_SET` to manage button states based on permission
 This approach involves directly exposing the conditions based on permissions in the code. This way, you can directly see in the code when the `Invite` button is disabled. 
 By reading the code from top to bottom, you can easily understand the logic for handling permissions.
 
-```typescript
+```tsx
 function Page() {
   const user = useUser();
 


### PR DESCRIPTION
When reading the *Reducing Eye Movement While Reading Code* (i.e. *코드를 읽을 때 시점 이동 줄이기*) page, some sample codes are displayed with incorrect syntax highlighting due to the invalid code block language identifier.

This pull request fixes the code-block language identifiers of some sample code. (`typescript` → `tsx`)