### PR TITLE
Fix: Avoid implicit type coercion in validation logic examples

### DIFF
--- a/code/examples/form-fields.md
+++ b/code/examples/form-fields.md
@@ -39,7 +39,7 @@ export function Form() {
         <input
           {...register("name", {
             validate: (value) =>
-              (isEmptyStringOrNil(value) ? "이름을 입력해주세요." : ""),
+              isEmptyStringOrNil(value) ? "이름을 입력해주세요." : ""
           })}
           placeholder="이름"
         />

--- a/en/code/examples/form-fields.md
+++ b/en/code/examples/form-fields.md
@@ -38,7 +38,7 @@ export function Form() {
         <input
           {...register("name", {
             validate: (value) =>
-              (isEmptyStringOrNil(value) ? "Please enter your name." : ""),
+              isEmptyStringOrNil(value) ? "Please enter your name." : ""
           })}
           placeholder="Name"
         />


### PR DESCRIPTION
- Replaced implicit type coercion (`!value`) in the validation logic with an explicit comparison using `value.trim() === ""`.
- Ensures that input containing only whitespace is also treated as invalid.

ref: https://github.com/toss/frontend-fundamentals/discussions/21