### PR TITLE
fix: Add trailing slashes to navigation links

### DIFF
--- a/.vitepress/en.mts
+++ b/.vitepress/en.mts
@@ -27,7 +27,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: "Easily Modifiable Code",
-          link: "/en/code"
+          link: "/en/code/"
         },
         {
           text: "Contributing",

--- a/.vitepress/ko.mts
+++ b/.vitepress/ko.mts
@@ -44,7 +44,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: "변경하기 쉬운 코드",
-          link: "/code"
+          link: "/code/"
         },
         {
           text: "기여하기",

--- a/en/index.md
+++ b/en/index.md
@@ -10,7 +10,7 @@ hero:
     alt: Frontend Fundamentals symbol
   actions:
     - text: Learn about good code
-      link: /en/code
+      link: /en/code/
     - theme: alt
       text: Communicate
       link: https://github.com/toss/frontend-fundamentals/discussions

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ hero:
     alt: Frontend Fundamentals symbol
   actions:
     - text: 좋은 코드의 기준 알아보기
-      link: /code
+      link: /code/
     - theme: alt
       text: 소통하기
       link: https://github.com/toss/frontend-fundamentals/discussions


### PR DESCRIPTION
## Description

Fixed an issue where links in the sidebar and footer navigation were missing trailing slashes, causing page mapping errors.

## Screenshots
<div>
<img width="259" alt="image" src="https://github.com/user-attachments/assets/38c1181e-87d3-4c11-a3db-4fd2649d1131" />
<img width="711" alt="image" src="https://github.com/user-attachments/assets/62c48e29-7463-462a-89e9-31e3b4fe226b" />
<div/>