### PR TITLE
fix: resolve layout shifting caused by component height differences

### DIFF
--- a/.vitepress/theme/Layout.vue
+++ b/.vitepress/theme/Layout.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import DefaultTheme from 'vitepress/theme'
-import Comments from './components/Comments.vue'
+import DefaultTheme from "vitepress/theme";
+import Comments from "./components/Comments.vue";
 
-const { Layout } = DefaultTheme
+const { Layout } = DefaultTheme;
 </script>
 
 <template>
@@ -12,3 +12,10 @@ const { Layout } = DefaultTheme
     </template>
   </Layout>
 </template>
+
+<style>
+html {
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
+}
+</style>


### PR DESCRIPTION
## Before & After

| Before                                                                                         | After                                                                                       |
|------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
| ![before](https://github.com/user-attachments/assets/52bea77b-39f4-46ad-a9f7-47665bde2497)     | ![after](https://github.com/user-attachments/assets/9cbdb9df-da21-4afa-856e-09fba8bd5d52)   |

### What Changed?
- 구성요소(컴포넌트) 높이에 따라 스크롤바가 생기거나 사라져, 레이아웃이 좌우로 흔들리는 문제가 있었습니다.
- `overflow-y: scroll;` (혹은 `scrollbar-gutter: stable;`) 설정으로 **항상 스크롤바 공간을 확보**하여 문제를 해결했습니다.

### Why This is Needed
- 짧은 문서(높이가 낮은)에서는 스크롤바가 없어서 레이아웃이 살짝 오른쪽으로 이동하는 “레이아웃 쉬프팅”이 발생했습니다.
- 사용자 경험을 해치지 않도록, **항상 일정한 스크롤바 영역**을 유지해 좌우 흔들림을 제거합니다.

### Additional Notes
- 일부 브라우저에서는 `scrollbar-gutter`를 지원하지 않을 수 있으므로, `overflow-y: scroll;`를 함께 적용해 폴백(fallback)을 마련했습니다.
- prettier 설정 (singleQuote, semi)에 맞춘 변경사항이 있습니다.
