### PR TITLE
Fix: Correct undefined data reference in InviteButton component

### DIFF
--- a/code/examples/login-start-page.md
+++ b/code/examples/login-start-page.md
@@ -181,7 +181,7 @@ function InviteButton({ name }) {
       onClick={async () => {
         const canInvite = await overlay.openAsync(({ isOpen, close }) => (
           <ConfirmDialog
-            title={`${data.name}님에게 공유해요`}
+            title={`${name}님에게 공유해요`}
             cancelButton={
               <ConfirmDialog.CancelButton onClick={() => close(false)}>
                 닫기

--- a/en/code/examples/login-start-page.md
+++ b/en/code/examples/login-start-page.md
@@ -179,7 +179,7 @@ function InviteButton({ name }) {
       onClick={async () => {
         const canInvite = await overlay.openAsync(({ isOpen, close }) => (
           <ConfirmDialog
-            title={`Share with ${data.name}`}
+            title={`Share with ${name}`}
             cancelButton={
               <ConfirmDialog.CancelButton onClick={() => close(false)}>
                 Close


### PR DESCRIPTION
## Changes
- Fix undefined data.name reference in InviteButton component
- Use name prop directly from component props

## Problem
The InviteButton component was trying to access data.name which doesn't exist in its scope, causing potential runtime errors.