### PR TITLE
Fix routing issue in en mode by updating "Contributing" link

### DIFF
--- a/.vitepress/en.mts
+++ b/.vitepress/en.mts
@@ -31,7 +31,7 @@ function sidebar(): DefaultTheme.Sidebar {
         },
         {
           text: "Contributing",
-          link: "/en/code/contributing"
+          link: "/en/code/community"
         }
       ]
     },


### PR DESCRIPTION
### Summary
- The link for the "Contributing" section in the sidebar was incorrectly pointing to "/en/code/contributing", which led to a 404 error.
- The link has now been updated to "/en/code/community", which resolves the issue and properly routes users to the correct page.