### PR TITLE
fix: update incorrect home redirection in en mode

### DIFF
--- a/.vitepress/en.mts
+++ b/.vitepress/en.mts
@@ -13,7 +13,7 @@ export const en = defineConfig({
 });
 
 function nav(): DefaultTheme.NavItem[] {
-  return [{ text: "Home", link: "/" }];
+  return [{ text: "Home", link: "/en/" }];
 }
 
 function sidebar(): DefaultTheme.Sidebar {


### PR DESCRIPTION
### Summary
- Update the "Home" button in the nav bar.
- Redirect to the Korean homepage (/) instead of the English homepage (/en) in English mode.