### PR TITLE
docs: update wrong codeblock highlight

### DIFF
--- a/code/examples/item-edit-modal.md
+++ b/code/examples/item-edit-modal.md
@@ -13,7 +13,7 @@ Props Drilling은 부모 컴포넌트와 자식 컴포넌트 사이에 결합도
 
 사용자가 입력한 키워드는 `keyword`, 선택할 수 있는 아이템은 `items`, 추천 아이템의 목록은 `recommendedItems` 프롭으로 전달돼요.
 
-```tsx 2,9-10,12-13,29-32
+```tsx 2,9-10,12-13,39-42
 function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
   const [keyword, setKeyword] = useState("");
 

--- a/en/code/examples/item-edit-modal.md
+++ b/en/code/examples/item-edit-modal.md
@@ -13,7 +13,7 @@ The user can enter a keyword to search the item list, and when the desired item 
 
 The keyword entered by the user is passed as the `keyword` prop, the selectable items are passed as the `items` prop, and the list of recommended items is passed as the `recommendedItems` prop.
 
-```tsx 2,9-10,12-13,29-32
+```tsx 2,9-10,12-13,39-42
 function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
   const [keyword, setKeyword] = useState("");
 


### PR DESCRIPTION
- update code highlight in `item-edit-modal`
- comparing the codeblock before and after #56 was committed.

URLs:

- https://frontend-fundamentals.com/code/examples/item-edit-modal.html#%F0%9F%93%9D-%E1%84%8F%E1%85%A9%E1%84%83%E1%85%B3-%E1%84%8B%E1%85%A8%E1%84%89%E1%85%B5
- https://frontend-fundamentals.com/en/code/examples/item-edit-modal.html#%F0%9F%93%9D-code-example

Before:

![image](https://github.com/user-attachments/assets/e6cda84d-fb03-4a85-9a44-b7c6029ae79a)

After:

![image](https://github.com/user-attachments/assets/52d3bc1f-3f97-4daa-a66b-56f31a842e12)

