### PR TITLE
fix: fix community link in ja docs sidebar

### DIFF
--- a/.vitepress/ja.mts
+++ b/.vitepress/ja.mts
@@ -82,7 +82,7 @@ function sidebar(): DefaultTheme.Sidebar {
           items: [
             {
               text: "紹介",
-              link: "/code/community"
+              link: "/ja/code/community"
             },
             {
               text: "⭐ 良い討論をまとめて見る",


### PR DESCRIPTION
### Summary
- fix community link in ja docs sidebar `/code/community` -> `/ja/code/community`