### PR TITLE
docs: update wrong codeblock highlight in Japanese

### DIFF
--- a/ja/code/examples/item-edit-modal.md
+++ b/ja/code/examples/item-edit-modal.md
@@ -13,7 +13,7 @@ Props Drillingは親コンポーネントと子コンポーネントの間に結
 
 ユーザーが入力したキーワードは`keyword`、選択可能なアイテムは`items`、推薦アイテムのリストは`recommendedItems`のpropsとして渡されます。
 
-```tsx 2,9-10,12-13,29-32
+```tsx 2,9-10,12-13,39-42
 function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
   const [keyword, setKeyword] = useState("");
 


### PR DESCRIPTION
I added the Japanese content that was missing in the changes from PR #119 

**URL**
https://frontend-fundamentals.com/ja/code/examples/item-edit-modal.html

**Before:**
![스크린샷 2025-01-20 오전 11 36 56](https://github.com/user-attachments/assets/564813a2-3719-4c6e-9fd1-0e109020e3ec)



**After:**
![스크린샷 2025-01-20 오전 11 50 20](https://github.com/user-attachments/assets/a6881558-e311-4f9c-a708-509da9dce3aa)
