### PR TITLE
fix: update giscus theme to change dynamically based on page theme

### DIFF
--- a/.vitepress/theme/components/Comments.vue
+++ b/.vitepress/theme/components/Comments.vue
@@ -1,13 +1,21 @@
 <script setup lang="ts">
-import { useData } from 'vitepress'
+import { watch } from "vue";
+import { useData } from "vitepress";
 
-const { frontmatter, title } = useData()
+const { frontmatter, title, isDark } = useData();
+watch(isDark, () => {
+  document.querySelector<HTMLIFrameElement>("iframe.giscus-frame")?.contentWindow?.postMessage(
+    { giscus: { setConfig: { theme: isDark.value ? "noborder_dark" : "noborder_light" } } },
+    "https://giscus.app"
+  );
+});
 </script>
 
 <template>
   <div v-if="frontmatter.comments !== false" :key="title" class="giscus" style="margin-top: 24px;">
     <component
       :is="'script'"
+      :data-theme="isDark ? 'noborder_dark' : 'noborder_light'"
       src="https://giscus.app/client.js"
       data-repo="toss/frontend-fundamentals"
       data-repo-id="R_kgDONfHk5g"
@@ -18,7 +26,6 @@ const { frontmatter, title } = useData()
       data-reactions-enabled="1"
       data-emit-metadata="0"
       data-input-position="bottom"
-      data-theme="preferred_color_scheme"
       data-lang="en"
       crossorigin="anonymous"
       data-loading="lazy"

--- a/.vitepress/theme/components/Comments.vue
+++ b/.vitepress/theme/components/Comments.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { watch } from "vue";
 import { useData } from "vitepress";
+import { watch } from "vue";
 
 const { frontmatter, title, isDark } = useData();
+
 watch(isDark, () => {
   document.querySelector<HTMLIFrameElement>("iframe.giscus-frame")?.contentWindow?.postMessage(
     { giscus: { setConfig: { theme: isDark.value ? "noborder_dark" : "noborder_light" } } },


### PR DESCRIPTION
Currently, the Giscus theme script is set to `data-theme="preferred_color_scheme"`, which reflects the user's preferred theme.

However, there is an issue where the Giscus theme does not change when the theme toggle button is clicked.

### Before
<table>
<tr>
<td>
<img width="752" alt="image" src="https://github.com/user-attachments/assets/4cf2e52f-44d9-4514-a099-da3e82ea6030" />
</td>
<td>
<img width="752" alt="image" src="https://github.com/user-attachments/assets/6ad06065-3f85-4d1a-9c78-29c3e769e6f1" />
</td>
</tr>
<tr>
<td align="center">
Device Preferred: <code>Dark</code> / Page: <code>Dark</code>
</td>
<td align="center">
Device Preferred: <code>Dark</code> / Page: <code>Light</code>
</td>
</tr>
</table>


### After
<table>
<tr>
<td>
<img width="752" alt="image" src="https://github.com/user-attachments/assets/858f451f-88fc-47c0-bcf7-0058e52d6d50" />
</td>
<td>
<img width="752" alt="image" src="https://github.com/user-attachments/assets/ef05645f-24f7-4e57-af39-3563ddd57b2d" />
</td>
</tr>
<tr>
<td align="center">
Device Preferred: <code>Dark</code> / Page: <code>Dark</code>
</td>
<td align="center">
Device Preferred: <code>Dark</code> / Page: <code>Light</code>
</td>
</tr>
</table>