### PR TITLE
Fix: Add Japanese locale and remove duplicate configurations

### DIFF
--- a/.vitepress/ja.mts
+++ b/.vitepress/ja.mts
@@ -189,7 +189,7 @@ function sidebar(): DefaultTheme.Sidebar {
 }
 
 export const search: DefaultTheme.LocalSearchOptions["locales"] = {
-  root: {
+  ja: {
     translations: {
       button: {
         buttonText: "検索",

--- a/.vitepress/ja.mts
+++ b/.vitepress/ja.mts
@@ -5,30 +5,6 @@ export const ja = defineConfig({
   title: "Frontend Fundamentals",
   description: "変更しやすいフロントエンドコードのためのガイドライン",
   lastUpdated: true,
-  head: [
-    ["link", { rel: "icon", href: "/images/favicon.ico" }],
-    [
-      "meta",
-      {
-        property: "og:image",
-        content: "https://static.toss.im/illusts/ff-meta.png"
-      }
-    ],
-    [
-      "meta",
-      {
-        name: "twitter:image",
-        content: "https://static.toss.im/illusts/ff-meta.png"
-      }
-    ],
-    [
-      "meta",
-      {
-        name: "twitter:card",
-        content: "https://static.toss.im/illusts/ff-meta.png"
-      }
-    ]
-  ],
   themeConfig: {
     logo: "/images/ff-symbol.svg",
     nav: nav(),

--- a/.vitepress/shared.mts
+++ b/.vitepress/shared.mts
@@ -1,5 +1,6 @@
 import { defineConfig, HeadConfig } from "vitepress";
 import { search as koSearch } from "./ko.mts";
+import { search as jaSearch } from "./ja.mts";
 
 export const shared = defineConfig({
   lastUpdated: true,
@@ -30,11 +31,15 @@ export const shared = defineConfig({
 
   transformHead: ({ pageData }) => {
     const head: HeadConfig[] = [];
-    const title = pageData.frontmatter.title || pageData.title || 'Frontend Fundamentals';
-    const description = pageData.frontmatter.description || pageData.description || 'Guidelines for easily modifiable frontend code';
+    const title =
+      pageData.frontmatter.title || pageData.title || "Frontend Fundamentals";
+    const description =
+      pageData.frontmatter.description ||
+      pageData.description ||
+      "Guidelines for easily modifiable frontend code";
 
-    head.push(['meta', { property: 'og:title', content: title }]);
-    head.push(['meta', { property: 'og:description', content: description }]);
+    head.push(["meta", { property: "og:title", content: title }]);
+    head.push(["meta", { property: "og:description", content: description }]);
 
     return head;
   },
@@ -50,7 +55,8 @@ export const shared = defineConfig({
       provider: "local",
       options: {
         locales: {
-          ...koSearch
+          ...koSearch,
+          ...jaSearch
         }
       }
     },

--- a/ja/code/examples/user-policy.md
+++ b/ja/code/examples/user-policy.md
@@ -93,7 +93,7 @@ function Page() {
 function Page() {
   const user = useUser();
   const policy = {
-    admin: { canInvite: true, canRead: true },
+    admin: { canInvite: true, canView: true },
     viewer: { canInvite: false, canView: true }
   }[user.role];
 


### PR DESCRIPTION
Improve Japanese locale support and configuration:

- Fix incorrectly configured Japanese locale in VitePress search (was being ignored)

  **Before/After screenshots:**
  <img width="1439" alt="image" src="https://github.com/user-attachments/assets/139ac5c8-8621-4488-929c-03d573f482e9" />

- Remove duplicate head configurations from ja.mts (now using shared config)
  (reason: https://github.com/toss/frontend-fundamentals/pull/49)
- Fix permission naming consistency (canView → canRead)
