### PR TITLE
Feat: Improve Giscus theme visibility and add i18n support

### DIFF
--- a/.vitepress/theme/components/Comments.vue
+++ b/.vitepress/theme/components/Comments.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useData } from "vitepress";
 import { useGiscusTheme } from "../hooks/useGiscusTheme";
-import { GISCUS_THEME } from "../utils";
+import { GISCUS_THEME, getGiscusLang } from "../utils";
 
 const { frontmatter, title, lang, isDark } = useData();
 useGiscusTheme();
@@ -27,7 +27,7 @@ useGiscusTheme();
       data-reactions-enabled="1"
       data-emit-metadata="0"
       data-input-position="bottom"
-      :data-lang="lang"
+      :data-lang="getGiscusLang(lang)"
       crossorigin="anonymous"
       data-loading="lazy"
       async

--- a/.vitepress/theme/components/Comments.vue
+++ b/.vitepress/theme/components/Comments.vue
@@ -2,7 +2,7 @@
 import { useData } from "vitepress";
 import { watch } from "vue";
 
-const { frontmatter, title, isDark } = useData();
+const { frontmatter, title, lang, isDark } = useData();
 
 watch(isDark, () => {
   document
@@ -40,7 +40,7 @@ watch(isDark, () => {
       data-reactions-enabled="1"
       data-emit-metadata="0"
       data-input-position="bottom"
-      data-lang="en"
+      :data-lang="lang"
       crossorigin="anonymous"
       data-loading="lazy"
       async

--- a/.vitepress/theme/components/Comments.vue
+++ b/.vitepress/theme/components/Comments.vue
@@ -1,23 +1,10 @@
 <script setup lang="ts">
 import { useData } from "vitepress";
-import { watch } from "vue";
+import { useGiscusTheme } from "../hooks/useGiscusTheme";
+import { GISCUS_THEME } from "../utils";
 
 const { frontmatter, title, lang, isDark } = useData();
-
-watch(isDark, () => {
-  document
-    .querySelector<HTMLIFrameElement>("iframe.giscus-frame")
-    ?.contentWindow?.postMessage(
-      {
-        giscus: {
-          setConfig: {
-            theme: isDark.value ? "dark_tritanopia" : "light_tritanopia"
-          }
-        }
-      },
-      "https://giscus.app"
-    );
-});
+useGiscusTheme();
 </script>
 
 <template>
@@ -29,7 +16,7 @@ watch(isDark, () => {
   >
     <component
       :is="'script'"
-      :data-theme="isDark ? 'dark_tritanopia' : 'light_tritanopia'"
+      :data-theme="isDark ? GISCUS_THEME.dark : GISCUS_THEME.light"
       src="https://giscus.app/client.js"
       data-repo="toss/frontend-fundamentals"
       data-repo-id="R_kgDONfHk5g"

--- a/.vitepress/theme/components/Comments.vue
+++ b/.vitepress/theme/components/Comments.vue
@@ -5,18 +5,31 @@ import { watch } from "vue";
 const { frontmatter, title, isDark } = useData();
 
 watch(isDark, () => {
-  document.querySelector<HTMLIFrameElement>("iframe.giscus-frame")?.contentWindow?.postMessage(
-    { giscus: { setConfig: { theme: isDark.value ? "noborder_dark" : "noborder_light" } } },
-    "https://giscus.app"
-  );
+  document
+    .querySelector<HTMLIFrameElement>("iframe.giscus-frame")
+    ?.contentWindow?.postMessage(
+      {
+        giscus: {
+          setConfig: {
+            theme: isDark.value ? "dark_tritanopia" : "light_tritanopia"
+          }
+        }
+      },
+      "https://giscus.app"
+    );
 });
 </script>
 
 <template>
-  <div v-if="frontmatter.comments !== false" :key="title" class="giscus" style="margin-top: 24px;">
+  <div
+    v-if="frontmatter.comments !== false"
+    :key="title"
+    class="giscus"
+    style="margin-top: 24px"
+  >
     <component
       :is="'script'"
-      :data-theme="isDark ? 'noborder_dark' : 'noborder_light'"
+      :data-theme="isDark ? 'dark_tritanopia' : 'light_tritanopia'"
       src="https://giscus.app/client.js"
       data-repo="toss/frontend-fundamentals"
       data-repo-id="R_kgDONfHk5g"

--- a/.vitepress/theme/hooks/useGiscusTheme.tsx
+++ b/.vitepress/theme/hooks/useGiscusTheme.tsx
@@ -1,0 +1,41 @@
+import { ref, watch, computed, onMounted } from "vue";
+import { useData } from "vitepress";
+import { GISCUS_ORIGIN, GISCUS_THEME, sendGiscusMessage } from "../utils";
+
+export function useGiscusTheme() {
+  const { isDark } = useData();
+  const isIframeLoaded = ref(false);
+
+  const syncTheme = () => {
+    sendGiscusMessage({
+      setConfig: {
+        theme: isDark.value ? GISCUS_THEME.dark : GISCUS_THEME.light
+      }
+    });
+  };
+
+  const setupThemeHandler = () => {
+    window.addEventListener("message", (event) => {
+      if (event.origin === GISCUS_ORIGIN && event.data?.giscus != null) {
+        isIframeLoaded.value = true;
+        syncTheme();
+      }
+    });
+  };
+
+  onMounted(() => {
+    setupThemeHandler();
+  });
+
+  watch(isDark, () => {
+    if (isIframeLoaded.value) {
+      syncTheme();
+    }
+  });
+
+  return {
+    theme: computed(() =>
+      isDark.value ? GISCUS_THEME.dark : GISCUS_THEME.light
+    )
+  };
+}

--- a/.vitepress/theme/utils/index.ts
+++ b/.vitepress/theme/utils/index.ts
@@ -1,9 +1,19 @@
 export const GISCUS_ORIGIN = "https://giscus.app" as const;
 
+export const GISCUS_LANG_MAP = {
+  ko: "ko",
+  en: "en",
+  ja: "ja"
+} as const;
+
 export const GISCUS_THEME = {
   light: "light_tritanopia",
   dark: "dark_tritanopia"
 };
+
+export function getGiscusLang(lang) {
+  return GISCUS_LANG_MAP[lang] || "en";
+}
 
 export function sendGiscusMessage<T>(message: T) {
   const iframe = document.querySelector<HTMLIFrameElement>(

--- a/.vitepress/theme/utils/index.ts
+++ b/.vitepress/theme/utils/index.ts
@@ -1,0 +1,15 @@
+export const GISCUS_ORIGIN = "https://giscus.app" as const;
+
+export const GISCUS_THEME = {
+  light: "light_tritanopia",
+  dark: "dark_tritanopia"
+};
+
+export function sendGiscusMessage<T>(message: T) {
+  const iframe = document.querySelector<HTMLIFrameElement>(
+    "iframe.giscus-frame"
+  );
+  if (!iframe) return;
+
+  iframe.contentWindow?.postMessage({ giscus: message }, GISCUS_ORIGIN);
+}


### PR DESCRIPTION
- Fix UI clarity by updating Giscus theme to tritanopia
- Add dynamic language support for comment section
- Ensure dark/light mode is properly applied after giscus iframe is fully loaded

#### Theme Comparison
- noborder theme (Before) vs tritanopia theme (After)
- Please review both themes and let me know your preference:
  <img width="2743" alt="light" src="https://github.com/user-attachments/assets/0e6f55f8-6bca-4157-9e1f-36b78ae5bfcb" />
  <img width="2743" alt="dark" src="https://github.com/user-attachments/assets/d685849c-7d61-4cc5-a4c1-5e315ca4092e" />

#### Language Support
- Dynamic language switching based on user preferences
  <img width="2283" alt="lang" src="https://github.com/user-attachments/assets/63235819-a5cd-4258-8b1e-fe510af34f37" />

#### Theme consistency
- Maintain theme consistency by applying giscus theme after load
  ![consistency](https://github.com/user-attachments/assets/c94ebd7b-fbb3-424e-909b-a5fb5b0e0fc8)
