### PR TITLE
Fix: Correct typos in English documentation

### DIFF
--- a/en/code/examples/item-edit-modal.md
+++ b/en/code/examples/item-edit-modal.md
@@ -92,7 +92,7 @@ function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}
         />
-        <Button onClick={onClose}>닫기</Button>
+        <Button onClick={onClose}>Close</Button>
       </div>
       <ItemEditList
         keyword={keyword}

--- a/en/code/examples/use-user.md
+++ b/en/code/examples/use-user.md
@@ -44,7 +44,7 @@ When code performing the same type of action does not follow consistent rules, i
 
 ### ✏️ Work on Improving
 
-By making hooks that call server APIs consistently return a `Query` object, as shown in the following example, you can enhance the predictability of the code for your
+By making hooks that call server APIs consistently return a `Query` object, as shown in the following example, you can enhance the predictability of the code for your teammates.
 
 ```typescript 9,18
 import { useQuery } from '@tanstack/react-query';


### PR DESCRIPTION
## 📝 Key Changes
- Complete unfinished sentence in `use-user.md`
- Change Korean `닫기` to `Close` in `item-edit-modal.md`
## 🖼️ Before and After Comparison
Simple text corrections in English documentation files. No visual changes.
