### PR TITLE
Fix: Improve grammar and localize link

### DIFF
--- a/en/code/examples/condition-name.md
+++ b/en/code/examples/condition-name.md
@@ -30,7 +30,7 @@ In this code, anonymous functions and conditions are intricately intertwined. Th
 
 There are many contexts for the reader to consider at once, which reduces readability. [^1]
 
-[^1]: According to [The Programmer's Brain](https://www.yes24.com/product/goods/105911017), the number of pieces of information that the human brain can store at one time is six.
+[^1]: According to [The Programmer's Brain]([https://www.yes24.com/product/goods/105911017](https://www.amazon.com/Programmers-Brain-Every-Programmer-Cognition/dp/B09NDVG2DW/ref=sr_1_1?crid=9GGEWPMGSL8Y&dib=eyJ2IjoiMSJ9.AF5Dcf0-L-uK6TtJShyWO_10--nMWYYt347wx3dfFsot6wGbgpz_Mn5XMp9Yv-Dok-XO31xYrb3qcx4VHzmvgH2WwCwpwPSGcfleagpa3sw78VkagAXyim4LIjFL9VTTWZemu1tTng4B6rtuPrrOveuu77Eme6QUtqqaTe6Q9vHejb4QwlvkhMBL1-9f6ixQBnvYmqlgZeeB09xB5ottOCf79StZNty_Z70W876zMSg.oDUVogfe2uXKb3VZqJAvyqrmLnE8o9zJSs7gfNNfdwA&dib_tag=se&keywords=The+Programmer%27s+Brain%3A&qid=1738067574&s=books&sprefix=the+programmer%27s+brain+%2Cstripbooks-intl-ship%2C236&sr=1-1)), the number of pieces of information that the human brain can store at one time is six.
 
 ## ✏️ Work on Improving
 

--- a/en/code/examples/submit-button.md
+++ b/en/code/examples/submit-button.md
@@ -11,8 +11,8 @@ It may also include a large number of branches in the implementation, making it 
 
 The `<SubmitButton />` component below behaves differently depending on the user's permission.
 
-- If the user's permission is read-only (`"viewer"`), the invite button is disabled and the animation is not played.
-- If the user is a regular user, the invite button can be used and the animation is played.
+- If the user's permission is read-only (`"viewer"`), the invite button is disabled and the animation does not play.
+- If the user is a regular user, the invite button is enabled and the animation plays.
 
 ```tsx
 function SubmitButton() {


### PR DESCRIPTION
## 📝 Key Changes
- Revised grammar considering natural flow `submit-button.md`
- Replaced the Yes24 link with an Amazon link for localization, as Yes24 is not commonly used in English-speaking countries and Amazon is a widely recognized online bookstore. `condition-name.md`

## 🖼️ Before and After Comparison
Simple text corrections in English documentation files. No visual changes.
