### PR TITLE
Fix: Add missing syntax and normalize Auth Token usage

### DIFF
--- a/ch/code/examples/code-directory.md
+++ b/ch/code/examples/code-directory.md
@@ -69,7 +69,7 @@
 例如，假设一个域(`Domain1`)的子代码中引用另一个域(`Domain2`)的源代码，如下所示：
 
 ```typescript
-import { useFoo } '../../../Domain2/hooks/useFoo'
+import { useFoo } from '../../../Domain2/hooks/useFoo'
 ```
 
 如果遇到这样的 import 语句，就能很容易地意识到引用了错误的文件。

--- a/ch/code/examples/http.md
+++ b/ch/code/examples/http.md
@@ -21,7 +21,9 @@ export const http = {
   async get(url: string) {
     const token = await fetchToken();
 
-    return httpLibrary.get(url);
+    return httpLibrary.get(url, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
   }
 };
 ```

--- a/code/examples/code-directory.md
+++ b/code/examples/code-directory.md
@@ -69,7 +69,7 @@
 예를 들어, 다음과 같이 한 도메인(`Domain1`)의 하위 코드에서 다른 도메인(`Domain2`)의 소스 코드를 참조한다고 생각해 볼게요.
 
 ```typescript
-import { useFoo } '../../../Domain2/hooks/useFoo'
+import { useFoo } from '../../../Domain2/hooks/useFoo'
 ```
 
 이런 import 문을 만난다면 잘못된 파일을 참조하고 있다는 것을 쉽게 인지할 수 있게 돼요.

--- a/code/examples/form-fields.md
+++ b/code/examples/form-fields.md
@@ -98,7 +98,7 @@ const schema = z.object({
   email: z
     .string()
     .min(1, "이메일을 입력해주세요.")
-    .email("유효한 이메일 주소를 입력해주세요")
+    .email("유효한 이메일 주소를 입력해주세요.")
 });
 
 export function Form() {

--- a/code/examples/http.md
+++ b/code/examples/http.md
@@ -21,7 +21,9 @@ export const http = {
   async get(url: string) {
     const token = await fetchToken();
 
-    return httpLibrary.get(url);
+    return httpLibrary.get(url, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
   }
 };
 ```

--- a/en/code/examples/code-directory.md
+++ b/en/code/examples/code-directory.md
@@ -69,7 +69,7 @@ If you place code files that are modified together under a single directory, it 
 For example, consider a case where the sub-code of one domain (`Domain1`) references the source code of another domain (`Domain2`).
 
 ```typescript
-import { useFoo } '../../../Domain2/hooks/useFoo'
+import { useFoo } from '../../../Domain2/hooks/useFoo'
 ```
 
 When you encounter such an import statement, you can easily recognize that the wrong file is being referenced.

--- a/en/code/examples/http.md
+++ b/en/code/examples/http.md
@@ -20,7 +20,9 @@ export const http = {
   async get(url: string) {
     const token = await fetchToken();
 
-    return httpLibrary.get(url);
+    return httpLibrary.get(url, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
   }
 };
 ```

--- a/ja/code/examples/code-directory.md
+++ b/ja/code/examples/code-directory.md
@@ -69,7 +69,7 @@
 例えば、次のようにあるドメイン（`Domain1`）の下にあるコードで別のドメイン（`Domain2`）のソースコードを参照していると考えてみましょう。
 
 ```typescript
-import { useFoo } '../../../Domain2/hooks/useFoo'
+import { useFoo } from '../../../Domain2/hooks/useFoo'
 ```
 
 このような import 文に遭遇した場合、誤ったファイルを参照していることを容易に認識できるようになります。

--- a/ja/code/examples/http.md
+++ b/ja/code/examples/http.md
@@ -21,7 +21,9 @@ export const http = {
   async get(url: string) {
     const token = await fetchToken();
 
-    return httpLibrary.get(url);
+    return httpLibrary.get(url, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
   }
 };
 ```


### PR DESCRIPTION
## 📝 Key Changes
Fixes three syntax issues:
- Adds missing period in email validation message - https://github.com/toss/frontend-fundamentals/commit/c4bda53e6fb7239135f469d6bcbfef0ae7a68408
- Adds missing 'from' keyword in import statement - https://github.com/toss/frontend-fundamentals/commit/db0a8700fa99721ec2eaca1804aa9f3d7315d5eb
- Changes requiring discussion:
  - [이름 겹치지 않게 관리하기](https://frontend-fundamentals.com/code/examples/http.html)
  - For consistency between `Code Example` and `Work on Improving` sections, I added Auth Token to `Code Example`. Based on the document context, I believe adding Auth Token was appropriate - could you confirm if this assessment is correct? - https://github.com/toss/frontend-fundamentals/commit/69a4ab221cb6523c579351e336b6aa8864faade6


## 🖼️ Before and After Comparison
Simple text corrections in documentation files. No visual changes.