### PR TITLE
Fix: Badge Component Not Rendering

### DIFF
--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,8 +1,10 @@
+import DefaultTheme from "vitepress/theme";
 import Layout from "./Layout.vue";
 import * as amplitude from "@amplitude/analytics-browser";
 import "./custom.css";
 
 export default {
+  extends: DefaultTheme,
   Layout,
   async enhanceApp() {
     if (typeof window !== "undefined") {


### PR DESCRIPTION
## 📝 Key Changes
- Added DefaultTheme import from vitepress/theme
- Extended DefaultTheme in configuration to inherit base components
- Fixed by following the solution from [vuejs/vitepress#1576](https://github.com/vuejs/vitepress/issues/1576)

The Badge component in VitePress is part of the DefaultTheme package. Initially, we couldn't access it because we tried implementing a custom theme without importing DefaultTheme.


## 🖼️ Before and After Comparison
Finally, the badge is visible!
|<img width="1457" alt="before" src="https://github.com/user-attachments/assets/584eaa1b-8b0a-4272-91d3-dbba5ab670b5" />|<img width="1457" alt="after" src="https://github.com/user-attachments/assets/36ac2709-1e9c-4e06-aab9-db748dc70595" />|
|:---:|:---:|
|**Before**|**After**|
