### PR TITLE
Revise the Giscus index to use document titles instead of path names

### DIFF
--- a/fundamentals/code-quality/.vitepress/config.mts
+++ b/fundamentals/code-quality/.vitepress/config.mts
@@ -44,5 +44,6 @@ export default defineConfig({
     config: (md) => {
       md.use(footnote);
     }
-  }
+  },
+  titleTemplate: ':title'
 });


### PR DESCRIPTION
## 📝 Key Changes
<!-- Describe the purpose of this PR and the problem it resolves. -->
- Revise the Giscus index to use document titles instead of path names

## 🖼️ Before and After Comparison
<!-- Attach screenshots or a GIF showing the before and after changes. -->

- Change Path Example 1
<img width="1902" alt="스크린샷 2025-04-10 오후 5 12 55" src="https://github.com/user-attachments/assets/1d328ef3-665c-4e2c-b319-25515d13173c" />

- Change Path Example 2
<img width="1269" alt="image" src="https://github.com/user-attachments/assets/823f2fb1-a9a0-4cc7-88a8-a6af3fe71d9a" />

