### PR TITLE
fix broken image path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Frontend Fundamentals](./public/images/ff-meta.png)
+![Frontend Fundamentals](./images/ff-meta.png)
 
 # Frontend Fundamentals
 


### PR DESCRIPTION
## 📝 Key Changes
- 기존 이미지 경로인 ./public/images/ff-meta.png는 GitHub에서 렌더링되지 않아 ./images/ff-meta.png로 수정했습니다.

English
- The original path ./public/images/ff-meta.png did not render on GitHub, so it was changed to ./images/ff-meta.png.

## 🖼️ Before and After Comparison
**Before**
<img width="1260" alt="스크린샷 2025-04-10 오후 7 38 14" src="https://github.com/user-attachments/assets/c8704f10-4cb5-42bc-bb59-24a17c0a27d1" />

**After**
<img width="1304" alt="스크린샷 2025-04-10 오후 7 47 12" src="https://github.com/user-attachments/assets/20e0bf28-b0b1-4239-b718-5d873930762b" />

