### PR TITLE
fix: 수정된 sideEffects 필드 값을 false로 변경하여 부수 효과 없는 모듈만 남기도록 안내

### DIFF
--- a/fundamentals/bundling/deep-dive/optimization/bundle-analyzer.md
+++ b/fundamentals/bundling/deep-dive/optimization/bundle-analyzer.md
@@ -151,6 +151,6 @@ yarn dedupe
 부수 효과가 있는 모듈은 트리 셰이킹 대상에서 제외돼요. 순수 모듈만 남겨 번들을 최적화하세요.
 
 * 웹팩의 `webpack-cli --json` 또는 `StatsWriterPlugin`을 이용해 Side Effect 모듈을 찾으세요.
-* `package.json`의 `sideEffects: true` 필드를 설정해 Side Effect가 없는 모듈만 남기세요.
+* `package.json`의 `sideEffects: false` 필드를 설정해 Side Effect가 없는 모듈만 남기세요.
 
 


### PR DESCRIPTION
## 📝 Key Changes

번들 최적화를 위해 package.json에 "sideEffects": false 설정을 추가했습니다.

## 🖼️ Before and After Comparison

기존에는 모든 모듈이 부수 효과가 있는 것으로 간주되어, 사용되지 않는 코드도 번들에 포함되는 문제가 있었습니다. sideEffects를 false로 설정함으로써 트리 셰이킹이 정상적으로 동작하게 되어, 번들 크기를 줄이고 불필요한 코드를 제거할 수 있게 되었습니다.
