### PR TITLE
fix: move rollup-plugin-visualizer to correct Rollup plugin section in Vite config

### DIFF
--- a/fundamentals/bundling/deep-dive/optimization/bundle-analyzer.md
+++ b/fundamentals/bundling/deep-dive/optimization/bundle-analyzer.md
@@ -69,13 +69,17 @@ import { defineConfig } from 'vite';
 import { visualizer } from 'rollup-plugin-visualizer';
 
 export default defineConfig({
-  plugins: [
-    visualizer({
-      open: true,
-      filename: 'dist/stats.html',
-      template: 'treemap',
-    }),
-  ],
+  build: {
+    rollupOptions: {
+      plugins: [
+        visualizer({
+          open: true,
+          filename: 'dist/stats.html',
+          template: 'treemap',
+        }),
+      ],
+    },
+  },
 });
 ```
 


### PR DESCRIPTION
## 📝 Key Changes
기존 `vite.config.js` 파일에서 `rollup-plugin-visualizer`가 `plugins` 루트에 잘못 설정되어 있던 문제를 수정했습니다.  
`rollup-plugin-visualizer`는 Vite 전용 플러그인이 아니라 Rollup 플러그인이기 때문에,  
Vite 설정 내부의 `build.rollupOptions.plugins` 경로에 위치해야 정상적으로 동작합니다.

## 🖼️ Before and After Comparison
|**Before**|
```js
// vite.config.js
import { defineConfig } from 'vite';
import { visualizer } from 'rollup-plugin-visualizer';

export default defineConfig({
  plugins: [
    visualizer({
      open: true,
      filename: 'dist/stats.html',
      template: 'treemap',
    }),
  ],
});
```

|**After**|

```js
// vite.config.js
import { defineConfig } from 'vite';
import { visualizer } from 'rollup-plugin-visualizer';

export default defineConfig({
  build: {
    rollupOptions: {
      plugins: [
        visualizer({
          open: true,
          filename: 'dist/stats.html',
          template: 'treemap',
        }),
      ],
    },
  },
});
```
