### PR TITLE
fix: Windows 11 Chrome에서 Toss Product Sans 폰트 미적용 문제 해결

### DIFF
--- a/fundamentals/bundling/.vitepress/config.mts
+++ b/fundamentals/bundling/.vitepress/config.mts
@@ -146,6 +146,17 @@ export default defineConfig({
       { rel: "icon", type: "image/x-icon", href: "/bundling/images/favicon.ico" }
     ],
     [
+      "link",
+      {
+        rel: "stylesheet",
+        fetchpriority: "low",
+        href: "https://static.toss.im/tps/others.css",
+        media: "none",
+        onload: "this.onload=null; this.media='all'",
+        crossorigin: "anonymous"
+      }
+    ],
+    [
       "meta",
       {
         property: "og:image",

--- a/fundamentals/bundling/.vitepress/config.mts
+++ b/fundamentals/bundling/.vitepress/config.mts
@@ -3,20 +3,20 @@ import footnote from "markdown-it-footnote";
 import path from "node:path";
 import { createRequire } from "node:module";
 import { tabsMarkdownPlugin } from 'vitepress-plugin-tabs'
-import { sharedConfig } from './shared.mjs';
+import { shared } from './shared.mjs';
 
 const require = createRequire(import.meta.url);
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  ...sharedConfig,
+  ...shared,
   title: "Bundling Fundamentals",
   description: "프론트엔드 번들링의 모든 것",
   ignoreDeadLinks: false,
   base: "/bundling/",
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
-    ...sharedConfig.themeConfig,
+    ...shared.themeConfig,
     nav: [
       { text: "홈", link: "/" },
     ],
@@ -140,44 +140,7 @@ export default defineConfig({
       md.use(tabsMarkdownPlugin);
     },
   },
-  head: [
-    [
-      "link",
-      { rel: "icon", type: "image/x-icon", href: "/bundling/images/favicon.ico" }
-    ],
-    [
-      "link",
-      {
-        rel: "stylesheet",
-        fetchpriority: "low",
-        href: "https://static.toss.im/tps/others.css",
-        media: "none",
-        onload: "this.onload=null; this.media='all'",
-        crossorigin: "anonymous"
-      }
-    ],
-    [
-      "meta",
-      {
-        property: "og:image",
-        content: "https://static.toss.im/illusts/bf-meta.png"
-      }
-    ],
-    [
-      "meta",
-      {
-        name: "twitter:image",
-        content: "https://static.toss.im/illusts/bf-meta.png"
-      }
-    ],
-    [
-      "meta",
-      {
-        name: "twitter:card",
-        content: "summary"
-      }
-    ],
-  ],
+  
   vite: {
     resolve: {
       alias: [

--- a/fundamentals/bundling/.vitepress/shared.mts
+++ b/fundamentals/bundling/.vitepress/shared.mts
@@ -28,12 +28,42 @@ const search: DefaultTheme.LocalSearchOptions["locales"] = {
 };
 
 
-export const sharedConfig = defineConfig({
+export const shared = defineConfig({
   lastUpdated: true,
   head: [
     [
       "link",
-      { rel: "icon", type: "image/x-icon", href: "/images/favicon.ico" }
+      {
+        rel: "preconnect",
+        href: "https://static.toss.im",
+        crossorigin: "anonymous"
+      }
+    ],
+    [
+      "link",
+      {
+        rel: "stylesheet",
+        fetchpriority: "low",
+        href: "https://static.toss.im/tps/main.css",
+        media: "none",
+        onload: "this.onload=null; this.media='all'",
+        crossorigin: "anonymous"
+      }
+    ],
+    [
+      "link",
+      {
+        rel: "stylesheet",
+        fetchpriority: "low",
+        href: "https://static.toss.im/tps/others.css",
+        media: "none",
+        onload: "this.onload=null; this.media='all'",
+        crossorigin: "anonymous"
+      }
+    ],
+    [
+      "link",
+      { rel: "icon", type: "image/x-icon", href: "/bundling/images/favicon.ico" }
     ],
     [
       "meta",


### PR DESCRIPTION
## 📝 Key Changes
- 문제
    - Windows 11 Chrome 137.0.7151.56 버전에서 번들링 콘텐츠의 폰트가 custom.css에 정의된 Toss Product Sans 폰트로 
로드되지 않는 문제 발생

- 원인
    - `fundamentals/bundling/.vitepress/config.mts`의 head 태그가 `fundamentals/bundling/.vitepress/shared.mts`의 head 태그와 중복되어 폰트 적용이 제대로 안되는 문제가 발생

- 해결 방법 및 수정사항
    - `fundamentals/bundling/.vitepress/config.mts`의 head 태그 제거 후 공통 설정은 `shared.mts`에서 관리하도록 일원화
    - `fundamentals/bundling/.vitepress/shared.mts`의 head 섹션에 Toss Product Sans 폰트를 적용하기 위한 스타일시트 추가
    - Favicon 설정 정리
        - 기존 기본 favicon (`{ rel: "icon", type: "image/x-icon", href: "/images/favicon.ico" }`) 삭제
        - 번들링 전용 favicon (`{ rel: "icon", type: "image/x-icon", href: "/bundling/images/favicon.ico" }`)만 유지 
    - `code-quality`와 변수명을 동일시 하기 위해 `sharedConfig` -> `shared` 로 변수명 변경
        - 개인 의견: 그러나 sharedConfig라는 변수명이 더 직관적인 것 같아 shared 대신 sharedConfig로 변수명을 통일해도 좋을 것 같습니다.

- 참고: `fundamentals/code-quality/.vitepress/shared.mts`와 `config.mts`의 코드를 참고했습니다.

## 🖼️ Before and After Comparison

| **Before** | **After** |
|------------|-----------|
| ![before1](https://github.com/user-attachments/assets/34a37c6c-39d4-43cf-a17d-c10cecbdd080) <br> ![before2](https://github.com/user-attachments/assets/644b813e-eb9c-4bf5-af6f-1f1882b91929) | ![after](https://github.com/user-attachments/assets/74c1b789-da60-4641-8909-b8faa4f28946) |
