### PR TITLE
fix: add missing import in use-page-state-coupling example

### DIFF
--- a/fundamentals/code-quality/code/examples/use-page-state-coupling.md
+++ b/fundamentals/code-quality/code/examples/use-page-state-coupling.md
@@ -78,7 +78,11 @@ export function usePageState() {
 다음 코드와 같이 각각의 쿼리 파라미터별로 별도의 Hook을 작성할 수 있어요.
 
 ```typescript
-import { useQueryParam } from "use-query-params";
+import { useCallback } from "react";
+import { 
+  NumberParam,
+  useQueryParam 
+} from "use-query-params";
 
 export function useCardIdQueryParam() {
   const [cardId, _setCardId] = useQueryParam("cardId", NumberParam);

--- a/fundamentals/code-quality/en/code/examples/use-page-state-coupling.md
+++ b/fundamentals/code-quality/en/code/examples/use-page-state-coupling.md
@@ -78,7 +78,11 @@ This hook can also be analyzed from a [readability](./use-page-state-readability
 You can create separate hooks for each query parameter, as shown in the following code.
 
 ```typescript
-import { useQueryParam } from "use-query-params";
+import { useCallback } from "react";
+import { 
+  NumberParam,
+  useQueryParam 
+} from "use-query-params";
 
 export function useCardIdQueryParam() {
   const [cardId, _setCardId] = useQueryParam("cardId", NumberParam);

--- a/fundamentals/code-quality/ja/code/examples/use-page-state-coupling.md
+++ b/fundamentals/code-quality/ja/code/examples/use-page-state-coupling.md
@@ -79,7 +79,11 @@ export function usePageState() {
 次のコードのように、各クエリパラメータごとに別々のHookを作成することができます。
 
 ```typescript
-import { useQueryParam } from "use-query-params";
+import { useCallback } from "react";
+import { 
+  NumberParam,
+  useQueryParam 
+} from "use-query-params";
 
 export function useCardIdQueryParam() {
   const [cardId, _setCardId] = useQueryParam("cardId", NumberParam);

--- a/fundamentals/code-quality/zh-hans/code/examples/use-page-state-coupling.md
+++ b/fundamentals/code-quality/zh-hans/code/examples/use-page-state-coupling.md
@@ -78,7 +78,11 @@ export function usePageState() {
 可以像下列代码一样，将每个查询参数分别编写单独的 Hook。
 
 ```typescript
-import { useQueryParam } from "use-query-params";
+import { useCallback } from "react";
+import { 
+  NumberParam,
+  useQueryParam 
+} from "use-query-params";
 
 export function useCardIdQueryParam() {
   const [cardId, _setCardId] = useQueryParam("cardId", NumberParam);


### PR DESCRIPTION
## 📝 Key Changes
<!-- Describe the purpose of this PR and the problem it resolves. -->

Fix missing imports (`NumberParam` and `useCallback`) in the `useCardIdQueryParam` example within the use-page-state-coupling documentation. 

The code example was referencing both `NumberParam` type and `useCallback` hook but missing the necessary import statements, which would cause compilation errors for developers following the example.

## 🖼️ Before and After Comparison
<!-- Attach screenshots or a GIF showing the before and after changes. -->

| **Before** | **After** |
|---|---|
| <img src="https://github.com/user-attachments/assets/5d226159-0bb3-4ac0-a112-d8875a208a30" width="320px" /> | <img src="https://github.com/user-attachments/assets/317a1f9d-7e8d-459c-905d-cae0665dae79" width="320px" />  |
