### PR TITLE
fix: remove incorrect lang code replacement to use full zh-hans in URLs

### DIFF
--- a/fundamentals/shared/components/OneNavigation.vue
+++ b/fundamentals/shared/components/OneNavigation.vue
@@ -36,7 +36,7 @@ const navigationItems = computed(() =>
   ONE_NAVIGATION_ITEMS.map((item) => ({
     ...item,
     href: item.href
-      .replace("/{lang}", `/${lang.value.split("-").at(0)}`)
+      .replace("/{lang}", `/${lang.value}`)
       .replace("/ko", "")
   }))
 );


### PR DESCRIPTION
## 📝 Key Changes
<!-- Describe the purpose of this PR and the problem it resolves. -->
중국어 간체(zh-hans)로 언어를 변경한 뒤 네비게이션에서 다른 메뉴로 이동할 때, URL의 lang이 `zh`로만 적용되어 404 오류가 발생하는 문제를 수정했습니다.

`OneNavigation.vue`에서 `lang.value`를 split하여 앞부분만 사용하는 부분을 제거해, 올바른 전체 언어 코드(`zh-hans`)가 URL에 반영되도록 변경했습니다.


## 🖼️ Before and After Comparison
<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:---:|:---:| 
|![2025-06-2211 37 38-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f167d749-e8d8-4a86-a137-f5636d878b78)|![2025-06-2211 36 02-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/9d7f32d5-8f66-4f16-a591-21e45cf593fd)|

