### PR TITLE
fix: add missing sidebar item for bundling tutorial

### DIFF
--- a/fundamentals/bundling/.vitepress/config.mts
+++ b/fundamentals/bundling/.vitepress/config.mts
@@ -59,6 +59,43 @@ export default defineConfig({
             text: "튜토리얼",
             items: [
               {
+                text: "기초부터 배우는 번들링",
+                items: [
+                  {
+                    text: "1. 번들링 시작하기",
+                    link: "/tutorial/basic",
+                  },
+                  {
+                    text: "2. TypeScript 코드 번들링하기",
+                    link: "/tutorial/typescript"
+                  },
+                  {
+                    text: "3. React와 함께 웹팩 사용하기",
+                    link: "/tutorial/with-react"
+                  },
+                     {
+                    text: "4. CSS 파일 번들링하기",
+                    link: "/tutorial/css"
+                  },
+                  {
+                    text: "5. 이미지와 폰트 다루기",
+                    link: "/tutorial/image-and-font"
+                  },
+                  {
+                    text: "6. 플러그인 추가하기",
+                    link: "/tutorial/plugin"
+                  },
+                  {
+                    text: "7. 개발 서버로 생산성 높이기",
+                    link: "/tutorial/dev-server"
+                  },
+                  {
+                    text: "8. 최적화하기",
+                    link: "/tutorial/optimization"
+                  },
+                ]
+              },
+              {
                 text: "웹팩으로 배우는 번들링",
                 items: [
                   {


### PR DESCRIPTION
## 📝 Key Changes
<!-- Describe the purpose of this PR and the problem it resolves. -->
안녕하세요! 
- 한국어 번들링 페이지 누락된 튜토리얼 사이드바 메뉴를 추가했습니다.

#### English
- Added missing tutorial sidebar menu for the Korean bundling page



## 🖼️ Before and After Comparison
<!-- Attach screenshots or a GIF showing the before and after changes. -->
| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/e72f266e-3960-49cf-83fd-d3f5577ea390) | ![image](https://github.com/user-attachments/assets/74250d56-5e50-4b25-b301-85f3b65dfedf) |

