### PR TITLE
docs: fix bundle:code-splitting wrong tab

### DIFF
--- a/fundamentals/bundling/deep-dive/optimization/code-splitting.md
+++ b/fundamentals/bundling/deep-dive/optimization/code-splitting.md
@@ -111,7 +111,6 @@ module.exports = {
 };
 ```
 
-:::
 
 
 


### PR DESCRIPTION
## 📝 Key Changes
<!-- Describe the purpose of this PR and the problem it resolves. -->
빌드 도구별 코드 스플리팅 설정에서 빠진 vite 탭을 추가했습니다.

## 🖼️ Before and After Comparison
<!-- Attach screenshots or a GIF showing the before and after changes. -->


| **Before** | **After** |
|:-:|:-:|
| <img width="726" height="292" alt="스크린샷 2025-07-11 오후 9 41 17" src="https://github.com/user-attachments/assets/62c29bda-7de1-482d-8919-42ea8b7d7fae" /> | <img width="732" height="363" alt="스크린샷 2025-07-11 오후 9 40 55" src="https://github.com/user-attachments/assets/da1815e7-4b24-4ab9-ab8c-db2bc2d40bbf" />|
