### PR TITLE
docs: Fix incorrect getByRole usage in example

### DIFF
--- a/fundamentals/a11y/why.md
+++ b/fundamentals/a11y/why.md
@@ -51,7 +51,7 @@ render(
   </ul>
 );
 const 복숭아 = screen.getByRole('listitem', { name: '복숭아' });
-const 복숭아저장버튼 = getByRole(복숭아, 'button', { name: '저장' })
+const 복숭아저장버튼 = within(복숭아).getByRole('button', { name: '저장' });
 expect(복숭아저장버튼).toBeInTheDocument();
 ```
 


### PR DESCRIPTION
## 📝 Key Changes

This PR corrects an example in the documentation that used an unsupported Testing Library API pattern:
`getByRole(element, ...)` → Updated to use `within(element).getByRole(...)` which is the recommended approach.

## 🖼️ Before and After Comparison
<!-- Attach screenshots or a GIF showing the before and after changes. -->

| Before | After |
|:------:|:-----:|
|  <img width="745" height="522" alt="스크린샷 2025-08-10 오후 1 18 17" src="https://github.com/user-attachments/assets/9d5615a3-6c59-4f75-b985-4cb5301fa312" />  | <img width="724" height="512" alt="스크린샷 2025-08-10 오후 1 17 47" src="https://github.com/user-attachments/assets/524f2c98-0d9d-4955-ac1c-740c31eae91e" />  |





