### PR TITLE
docs: invalid inline style fixed in item-edit-modal (KR & JP versions)

### DIFF
--- a/fundamentals/code-quality/code/examples/item-edit-modal.md
+++ b/fundamentals/code-quality/code/examples/item-edit-modal.md
@@ -107,7 +107,7 @@ function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
 function ItemEditBody({ children, onClose }) {
   return (
     <>
-      <div style="display: flex; justify-content: space-between;">
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
         <Input
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}
@@ -149,7 +149,7 @@ function ItemEditList({ children, onClose }) {
 
   return (
     <>
-      <div style="display: flex; justify-content: space-between;">
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
         <Input
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}

--- a/fundamentals/code-quality/ja/code/examples/item-edit-modal.md
+++ b/fundamentals/code-quality/ja/code/examples/item-edit-modal.md
@@ -104,7 +104,7 @@ function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
 function ItemEditBody({ children, onClose }) {
   return (
     <>
-      <div style="display: flex; justify-content: space-between;">
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
         <Input
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}


### PR DESCRIPTION
## 📝 Key Changes
Replaced invalid inline style usage in item-edit-modal.
The previous code incorrectly used an HTML style attribute string inside JSX.
It has been updated to use a JavaScript style object, ensuring proper React inline styling syntax.
The same incorrect source code was also present in the Korean and Japanese versions, which have been updated accordingly.

## 🖼️ Before and After Comparison

| Before | After |
|:------:|:-----:|
| <img width="1510" height="824" alt="스크린샷 Before" src="https://github.com/user-attachments/assets/5de0df85-4b90-4fe5-ba4a-396fc5fa26e6" /> | <img width="1510" height="824" alt="스크린샷 After" src="https://github.com/user-attachments/assets/0fad4e2b-65bf-40d0-80e9-83a41c5f19dd" /> |