### PR TITLE
docs: Unify animation function name in SubmitButton example to improve code clarity

### DIFF
--- a/fundamentals/code-quality/code/examples/submit-button.md
+++ b/fundamentals/code-quality/code/examples/submit-button.md
@@ -63,7 +63,7 @@ function ViewerSubmitButton() {
 
 function AdminSubmitButton() {
   useEffect(() => {
-    showAnimation();
+    showButtonAnimation();
   }, []);
 
   return <Button type="submit">Submit</Button>;

--- a/fundamentals/code-quality/en/code/examples/submit-button.md
+++ b/fundamentals/code-quality/en/code/examples/submit-button.md
@@ -63,7 +63,7 @@ function ViewerSubmitButton() {
 
 function AdminSubmitButton() {
   useEffect(() => {
-    showAnimation();
+    showButtonAnimation();
   }, []);
 
   return <Button type="submit">Submit</Button>;

--- a/fundamentals/code-quality/ja/code/examples/submit-button.md
+++ b/fundamentals/code-quality/ja/code/examples/submit-button.md
@@ -61,7 +61,7 @@ function ViewerSubmitButton() {
 
 function AdminSubmitButton() {
   useEffect(() => {
-    showAnimation();
+    showButtonAnimation();
   }, []);
 
   return <Button type="submit">Submit</Button>;

--- a/fundamentals/code-quality/zh-hans/code/examples/submit-button.md
+++ b/fundamentals/code-quality/zh-hans/code/examples/submit-button.md
@@ -63,7 +63,7 @@ function ViewerSubmitButton() {
 
 function AdminSubmitButton() {
   useEffect(() => {
-    showAnimation();
+    showButtonAnimation();
   }, []);
 
   return <Button type="submit">Submit</Button>;


### PR DESCRIPTION
## 📝 Key Changes

This PR improves the SubmitButton example in the documentation by unifying the animation function name from `showAnimation` to `showButtonAnimation` across all related components.

In the original example, the animation is played using the `showButtonAnimation()` function:
```tsx
function SubmitButton() {
  const isViewer = useRole() === "viewer";

  useEffect(() => {
    if (isViewer) {
      return;
    }
    showButtonAnimation();
  }, [isViewer]);

  return isViewer ? (
    <TextButton disabled>Submit</TextButton>
  ) : (
    <Button type="submit">Submit</Button>
  );
}
```

However, in the improved example, the animation function is called `showAnimation()`, which introduces inconsistency in function naming and reduces code readability.

Different function names may confuse readers into thinking these are different behaviors, even though they serve the same purpose.

Therefore, unifying both components to use the same function `showButtonAnimation()` improves code clarity and maintainability.


## 🖼️ Before and After Comparison
<!-- Attach screenshots or a GIF showing the before and after changes. -->

| Before | After |
|:------:|:-----:|
|  <img width="766" height="731" alt="스크린샷 2025-08-21 오후 11 03 19" src="https://github.com/user-attachments/assets/6b414103-c097-4feb-89df-87e8f9b1b0ef" />|   <img width="782" height="723" alt="스크린샷 2025-08-21 오후 11 03 12" src="https://github.com/user-attachments/assets/5a62e0a6-6b4d-4ae2-bd68-3521f0671929" />|
