### PR TITLE
docs: update README to add link to open A11y Fundamentals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ https://frontend-fundamentals.com/code-quality/en/
 
 - [Code Quality Fundamentals](https://frontend-fundamentals.com/code-quality/)
 - [Bundling Fundamentals](https://frontend-fundamentals.com/bundling/)
-- A11y Fundamentals (coming soon!)
+- [A11y Fundamentals](https://frontend-fundamentals.com/a11y/)
 
 ## Contributing
 


### PR DESCRIPTION
## 📝 Key Changes
This PR updates the README.md of Frontend Fundamentals project to reflect the current status of the A11y Fundamentals section.

- Changed the `A11y Fundamentals (coming soon!)` text to include an active link to the newly opened A11y Fundamentals documentation.
- This update improves accuracy and helps users easily access the accessibility fundamentals materials.


## 🖼️ Before and After Comparison
<!-- Attach screenshots or a GIF showing the before and after changes. -->

| Before | After |
|:------:|:-----:|
|  <img width="938" height="629" alt="스크린샷 2025-08-21 오후 11 18 40" src="https://github.com/user-attachments/assets/7cbfc1d6-16f0-4e4f-96f3-84595e71c183" />|   <img width="1015" height="633" alt="스크린샷 2025-08-21 오후 11 19 32" src="https://github.com/user-attachments/assets/e2ede679-bb3d-42f0-87ab-8cd58b9a7d3d" />|
