### PR TITLE
docs: update wording from ‘Hook’ to ‘function’ across multiple languages

### DIFF
--- a/fundamentals/code-quality/code/examples/magic-number-cohesion.md
+++ b/fundamentals/code-quality/code/examples/magic-number-cohesion.md
@@ -32,7 +32,7 @@ async function onLikeClick() {
 
 ::: info
 
-이 Hook은 [가독성](./magic-number-readability.md) 관점으로도 볼 수 있어요.
+이 함수는 [가독성](./magic-number-readability.md) 관점으로도 볼 수 있어요.
 
 :::
 

--- a/fundamentals/code-quality/code/examples/magic-number-readability.md
+++ b/fundamentals/code-quality/code/examples/magic-number-readability.md
@@ -1,4 +1,4 @@
-# 매직 넘버에 이름 붙이기
+훅# 매직 넘버에 이름 붙이기
 
 <div style="margin-top: 16px">
 <Badge type="info" text="가독성" />
@@ -36,7 +36,7 @@ async function onLikeClick() {
 
 ::: info
 
-이 Hook은 [응집도](./magic-number-cohesion.md) 관점으로도 볼 수 있어요.
+이 함수는 [응집도](./magic-number-cohesion.md) 관점으로도 볼 수 있어요.
 
 :::
 

--- a/fundamentals/code-quality/en/code/examples/magic-number-cohesion.md
+++ b/fundamentals/code-quality/en/code/examples/magic-number-cohesion.md
@@ -30,7 +30,7 @@ From the perspective that only one side of the code that needs to be modified to
 
 ::: info
 
-This hook can also be viewed from the perspective of [readability](./magic-number-readability.md).
+This function can also be viewed from the perspective of [readability](./magic-number-readability.md).
 
 :::
 

--- a/fundamentals/code-quality/en/code/examples/magic-number-readability.md
+++ b/fundamentals/code-quality/en/code/examples/magic-number-readability.md
@@ -35,7 +35,7 @@ When multiple developers work on the same code, the intention may not be accurat
 
 ::: info
 
-This Hook can also be viewed from the perspective of [cohesion](./magic-number-cohesion.md).
+This function can also be viewed from the perspective of [cohesion](./magic-number-cohesion.md).
 
 :::
 

--- a/fundamentals/code-quality/ja/code/examples/magic-number-cohesion.md
+++ b/fundamentals/code-quality/ja/code/examples/magic-number-cohesion.md
@@ -31,7 +31,7 @@ async function onLikeClick() {
 
 ::: info
 
-この Hook は[可読性](./magic-number-readability.md)の観点からも考えることができます。
+この Function は[可読性](./magic-number-readability.md)の観点からも考えることができます。
 
 :::
 

--- a/fundamentals/code-quality/ja/code/examples/magic-number-readability.md
+++ b/fundamentals/code-quality/ja/code/examples/magic-number-readability.md
@@ -36,7 +36,7 @@ async function onLikeClick() {
 
 ::: info
 
-この Hook は[凝集度](./magic-number-cohesion.md)の観点からも考えることができます。
+この Function は[凝集度](./magic-number-cohesion.md)の観点からも考えることができます。
 
 :::
 

--- a/fundamentals/code-quality/zh-hans/code/examples/magic-number-cohesion.md
+++ b/fundamentals/code-quality/zh-hans/code/examples/magic-number-cohesion.md
@@ -30,7 +30,7 @@ async function onLikeClick() {
 
 ::: info
 
-这个 Hook 也可以从 [可读性](./magic-number-readability.md) 的角度来考虑。
+这个 Function 也可以从 [可读性](./magic-number-readability.md) 的角度来考虑。
 
 :::
 

--- a/fundamentals/code-quality/zh-hans/code/examples/magic-number-readability.md
+++ b/fundamentals/code-quality/zh-hans/code/examples/magic-number-readability.md
@@ -35,7 +35,7 @@ async function onLikeClick() {
 
 ::: info
 
-这个 Hook 也可以从 [内聚性](./magic-number-cohesion.md) 的角度来考虑。
+这个 Function 也可以从 [内聚性](./magic-number-cohesion.md) 的角度来考虑。
 
 :::
 


### PR DESCRIPTION
## 📝 Key Changes
This PR updates the wording in the magic number documentation across multiple languages to improve accuracy and clarity.

- Changed the phrase referring to the example from "Hook" to "function" in Korean, English, Japanese, and Chinese texts.
- Korean: 이 Hook은 → 이 함수는
- English: This hook → This function
- Japanese: この Hook は → この Function は
- Chinese: 这个 Hook → 这个 Function

Using “function” better represents the example code, which is a general async function, not a React hook, preventing reader confusion.

This enhances consistency and improves reader understanding in all supported languages.

## 🖼️ Before and After Comparison


| Before | After |
|:------:|:-----:|
|  <img width="745" height="495" alt="스크린샷 2025-08-22 오전 12 53 48" src="https://github.com/user-attachments/assets/49d32d95-29a9-41df-a5be-139eb67301cc" />|  <img width="762" height="503" alt="스크린샷 2025-08-22 오전 12 53 43" src="https://github.com/user-attachments/assets/ee5f521d-b24b-4dc1-a250-27fa9ed99156" />|
