### PR TITLE
docs: fix correct style prop usage and prop passing in ItemEditModal composition example

### DIFF
--- a/fundamentals/code-quality/code/examples/item-edit-modal.md
+++ b/fundamentals/code-quality/code/examples/item-edit-modal.md
@@ -111,7 +111,7 @@ function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
 function ItemEditBody({ children, keyword, onKeywordChange, onClose }) {
   return (
     <>
-      <div style="display: flex; justify-content: space-between;">
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
         <Input
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}
@@ -141,26 +141,23 @@ function ItemEditModal({ open, onConfirm, onClose }) {
 
   return (
     <Modal open={open} onClose={onClose}>
-      <ItemEditBody onClose={onClose}>
+      <ItemEditBody 
+        keyword={keyword} 
+        onKeywordChange={setKeyword} 
+        onClose={onClose}
+      >
         <ItemEditList keyword={keyword} onConfirm={onConfirm} />
       </ItemEditBody>
     </Modal>
   );
 }
 
-function ItemEditList({ children, onClose }) {
+function ItemEditList({ keyword, onConfirm }) {
   const { items, recommendedItems } = useItemEditModalContext();
 
   return (
     <>
-      <div style="display: flex; justify-content: space-between;">
-        <Input
-          value={keyword}
-          onChange={(e) => onKeywordChange(e.target.value)}
-        />
-        <Button onClick={onClose}>닫기</Button>
-      </div>
-      {children}
+      {/* items, recommendedItems 렌더링 로직 */}
     </>
   );
 }

--- a/fundamentals/code-quality/code/examples/item-edit-modal.md
+++ b/fundamentals/code-quality/code/examples/item-edit-modal.md
@@ -92,7 +92,7 @@ function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
 
   return (
     <Modal open={open} onClose={onClose}>
-      <ItemEditBody 
+      <ItemEditBody
         keyword={keyword}
         onKeywordChange={setKeyword}
         onClose={onClose}
@@ -135,15 +135,15 @@ Context API를 활용하면, 데이터의 흐름을 간소화하고 계층 구�
 
 조합 패턴을 사용해도, 컴포넌트가 복잡하고 깊다면, ContextAPI를 사용함으로써 불필요한 Props Drilling을 제거할 수 있어요.
 
-```tsx 1,7,14
+```tsx 1,11,18
 function ItemEditModal({ open, onConfirm, onClose }) {
   const [keyword, setKeyword] = useState("");
 
   return (
     <Modal open={open} onClose={onClose}>
-      <ItemEditBody 
-        keyword={keyword} 
-        onKeywordChange={setKeyword} 
+      <ItemEditBody
+        keyword={keyword}
+        onKeywordChange={setKeyword}
         onClose={onClose}
       >
         <ItemEditList keyword={keyword} onConfirm={onConfirm} />
@@ -155,11 +155,7 @@ function ItemEditModal({ open, onConfirm, onClose }) {
 function ItemEditList({ keyword, onConfirm }) {
   const { items, recommendedItems } = useItemEditModalContext();
 
-  return (
-    <>
-      {/* items, recommendedItems 렌더링 로직 */}
-    </>
-  );
+  return <>{/* items, recommendedItems 렌더링 로직 */}</>;
 }
 ```
 

--- a/fundamentals/code-quality/ja/code/examples/item-edit-modal.md
+++ b/fundamentals/code-quality/ja/code/examples/item-edit-modal.md
@@ -89,7 +89,11 @@ function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
 
   return (
     <Modal open={open} onClose={onClose}>
-      <ItemEditBody onClose={onClose}>
+      <ItemEditBody
+        keyword={keyword}
+        onKeywordChange={setKeyword}
+        onClose={onClose}
+      >
         <ItemEditList
           keyword={keyword}
           items={items}
@@ -101,10 +105,10 @@ function ItemEditModal({ open, items, recommendedItems, onConfirm, onClose }) {
   );
 }
 
-function ItemEditBody({ children, onClose }) {
+function ItemEditBody({ children, keyword, onKeywordChange, onClose }) {
   return (
     <>
-      <div style="display: flex; justify-content: space-between;">
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
         <Input
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}
@@ -133,26 +137,23 @@ function ItemEditModal({ open, onConfirm, onClose }) {
 
   return (
     <Modal open={open} onClose={onClose}>
-      <ItemEditBody onClose={onClose}>
+      <ItemEditBody
+        keyword={keyword}
+        onKeywordChange={setKeyword}
+        onClose={onClose}
+      >
         <ItemEditList keyword={keyword} onConfirm={onConfirm} />
       </ItemEditBody>
     </Modal>
   );
 }
 
-function ItemEditList({ children, onClose }) {
+function ItemEditList({ keyword, onConfirm }) {
   const { items, recommendedItems } = useItemEditModalContext();
 
   return (
     <>
-      <div style="display: flex; justify-content: space-between;">
-        <Input
-          value={keyword}
-          onChange={(e) => onKeywordChange(e.target.value)}
-        />
-        <Button onClick={onClose}>閉じる</Button>
-      </div>
-      {children}
+      {/* items, recommendedItems レンダリングロジック */}
     </>
   );
 }

--- a/fundamentals/code-quality/ja/code/examples/item-edit-modal.md
+++ b/fundamentals/code-quality/ja/code/examples/item-edit-modal.md
@@ -131,7 +131,7 @@ function ItemEditBody({ children, keyword, onKeywordChange, onClose }) {
 Context APIを活用することで、データの流れを簡素化し、階層構造全体に簡単に共有することができます。
 コンポジションパターンを使用しても、コンポーネントが複雑で深い場合には、ContextAPIを使用することで不必要なProps Drillingを取り除くことができます。
 
-```tsx 1,7,14
+```tsx 1,11,18
 function ItemEditModal({ open, onConfirm, onClose }) {
   const [keyword, setKeyword] = useState("");
 
@@ -151,11 +151,7 @@ function ItemEditModal({ open, onConfirm, onClose }) {
 function ItemEditList({ keyword, onConfirm }) {
   const { items, recommendedItems } = useItemEditModalContext();
 
-  return (
-    <>
-      {/* items, recommendedItems レンダリングロジック */}
-    </>
-  );
+  return <>{/* items, recommendedItems レンダリングロジック */}</>;
 }
 ```
 


### PR DESCRIPTION
## 📝 Key Changes

- **Corrected style prop usage**:
  Updated inline style from `style="display: flex; justify-content: space-between;"` to `style={{ display: "flex", justifyContent: "space-between" }}` for valid JSX and consistency.

- **Added missing keyword prop**:
  Passed the required `keyword` prop to `ItemEditBody` for controlled input, ensuring correct state management and preventing uncontrolled behavior.

- **Fixed `ItemEditList` props and example comment**:
  Adjusted props for `ItemEditList` to match the component's usage, removing unrelated props from `ItemEditBody`.

This change applies to Korean and Japanese documents.

## 💬 Comment
Since ItemEditList is an example that shows how to use the Context API, the rendering logic is simply written in comments, but if you need the exact code, please let me know!

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->



| Before | After |
|:------:|:-----:|
| <img width="771" height="741" alt="스크린샷 2025-09-01 오후 1 17 30" src="https://github.com/user-attachments/assets/b1c7e692-a478-43d1-815b-9eb78d6c5236" />| <img width="774" height="579" alt="스크린샷 2025-09-01 오후 1 17 39" src="https://github.com/user-attachments/assets/c489e15e-62fc-4768-a1a7-fb38c05b6e17" />|
