### PR TITLE
fix: update favicon path from bundling to a11y

### DIFF
--- a/fundamentals/a11y/.vitepress/config.mts
+++ b/fundamentals/a11y/.vitepress/config.mts
@@ -147,7 +147,7 @@ export default defineConfig({
       {
         rel: "icon",
         type: "image/x-icon",
-        href: "/bundling/images/favicon.ico"
+        href: "/a11y/images/favicon.ico"
       }
     ],
     [


### PR DESCRIPTION
## 📝 Key Changes

<!-- Describe the purpose of this PR and the problem it resolves. -->

This PR fixes the favicon path for the **A11y Fundamentals** site.  
Previously, the favicon was incorrectly set to use the Bundling site’s favicon.  
The configuration has been updated so that the A11y site now loads its own favicon from `/a11y/images/favicon.ico`.

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
| <img width="937" height="538" alt="image" src="https://github.com/user-attachments/assets/73a34101-fc9e-471a-a5fe-c5ca7939e5f4" /> | <img width="942" height="557" alt="image" src="https://github.com/user-attachments/assets/408e6943-0774-44e8-955e-65261f4f2c3f" /> |