### PR TITLE
fix(code-quality): add base tag to resolve Giscus discussion link issue

### DIFF
--- a/fundamentals/code-quality/.vitepress/shared.mts
+++ b/fundamentals/code-quality/.vitepress/shared.mts
@@ -80,6 +80,7 @@ export const shared = defineConfig({
 
     head.push(["meta", { property: "og:title", content: title }]);
     head.push(["meta", { property: "og:description", content: description }]);
+    head.push(["base", { href: "/code-quality/" }]);
 
     return head;
   },


### PR DESCRIPTION
## Summary
Fixes #365 

ADd `<base>` tag to resolve incorrect link generation in Giscus disscussions for the code-quality section. 

 ## Problem
- Giscus was generating discussion links without the `/code-quality/` base path
- Links appeared as `/code/examples/...` instead of `/code-quality/code/examples/...`
- This caused 404 errors when clicking links within discussions