### PR TITLE
TIL > refactor: 피드 컨텐츠와 주간 TOP5 layout 사용성 개선

### DIFF
--- a/fundamentals/today-i-learned/src/components/features/auth/UnauthenticatedState.tsx
+++ b/fundamentals/today-i-learned/src/components/features/auth/UnauthenticatedState.tsx
@@ -1,25 +1,48 @@
 import { useAuth } from "@/contexts/AuthContext";
 import { Button } from "@/components/shared/ui/Button";
+import { css } from "@styled-system/css";
 
 export function UnauthenticatedState() {
   const { login } = useAuth();
 
   return (
-    <div className="flex flex-col items-center justify-center px-6 py-8 gap-4 w-full rounded-2xl bg-white">
-      {/* 메인 텍스트 */}
-      <h1 className="text-xl font-bold text-center text-black/80 tracking-tight leading-[130%]">
-        매일 한 줄, 오늘 배운 내용을 기록해봐요!
-      </h1>
+    <div className={container}>
+      <span className={title}>오늘 배운 내용을 기록하려면 로그인해 주세요</span>
 
-      {/* 버튼 */}
-      <Button
-        onClick={login}
-        variant="primary"
-        size="lg"
-        className="px-8 py-3 text-base font-bold"
-      >
+      <Button onClick={login} variant="primary" size="lg" className={button}>
         로그인하기
       </Button>
     </div>
   );
 }
+
+const container = css({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  paddingX: "2rem",
+  paddingY: "3rem",
+  gap: "1.5rem"
+});
+
+const title = css({
+  fontFamily: "Toss Product Sans OTF",
+  fontSize: "1.125rem",
+  fontWeight: "700",
+  fontStyle: "bold",
+  lineHeight: "130%",
+  letterSpacing: "-0.025em"
+});
+
+const button = css({
+  maxHeight: "2.5rem",
+  paddingX: "1rem",
+
+  fontFamily: "Toss Product Sans OTF",
+  fontSize: "1rem",
+  fontWeight: "700",
+  fontStyle: "bold",
+  lineHeight: "130%",
+  letterSpacing: "-0.025em"
+});

--- a/fundamentals/today-i-learned/src/components/features/discussions/PostCard.tsx
+++ b/fundamentals/today-i-learned/src/components/features/discussions/PostCard.tsx
@@ -113,21 +113,15 @@ export function PostCard({
           )}
         </div>
 
-        {/* 본문 */}
-        <div className={contentSection}>
-          {/* 제목과 내용 */}
-          <div className={contentContainer}>
-            {/* 제목 */}
-            <h2 className={postTitle}>{discussion.title}</h2>
+        {/* 제목 */}
+        <h2 className={postTitle}>{discussion.title}</h2>
 
-            {/* 내용 미리보기 */}
-            <div className={contentPreview}>
-              <MarkdownRenderer
-                content={discussion.body}
-                className={markdownContent}
-              />
-            </div>
-          </div>
+        {/* 내용 미리보기 */}
+        <div className={contentPreview}>
+          <MarkdownRenderer
+            content={discussion.body}
+            className={markdownContent}
+          />
         </div>
 
         <InteractionButtons
@@ -141,6 +135,7 @@ export function PostCard({
           variant="card"
         />
       </div>
+
       {EditPostModal}
     </Card>
   );
@@ -161,15 +156,15 @@ const cardContainer = css({
 const cardContent = css({
   display: "flex",
   flexDirection: "column",
-  padding: "1.5rem",
-  gap: "1.5rem"
+  padding: "1.5rem"
 });
 
 const headerSection = css({
   display: "flex",
   alignItems: "center",
   justifyContent: "space-between",
-  height: "2.5rem"
+  height: "2.5rem",
+  marginBottom: "1rem"
 });
 
 const userInfoContainer = css({
@@ -231,19 +226,8 @@ const timeStamp = css({
   color: "#979797"
 });
 
-const contentSection = css({
-  display: "flex",
-  flexDirection: "column",
-  gap: "1.25rem"
-});
-
-const contentContainer = css({
-  display: "flex",
-  flexDirection: "column",
-  gap: "1.25rem"
-});
-
 const postTitle = css({
+  marginBottom: "0.5rem",
   fontWeight: "700",
   fontSize: "22px",
   lineHeight: "130%",
@@ -260,6 +244,7 @@ const postTitle = css({
 
 const contentPreview = css({
   display: "-webkit-box",
+  marginBottom: "1rem",
   WebkitLineClamp: "3",
   // @ts-ignore
   WebkitBoxOrient: "vertical",

--- a/fundamentals/today-i-learned/src/components/features/discussions/PostCard.tsx
+++ b/fundamentals/today-i-learned/src/components/features/discussions/PostCard.tsx
@@ -156,7 +156,14 @@ const cardContainer = css({
 const cardContent = css({
   display: "flex",
   flexDirection: "column",
-  padding: "1.5rem"
+  padding: "1.5rem",
+  transition: "all 0.2s",
+  _hover: {
+    "& h2": {
+      color: "#0064FF",
+      opacity: 0.8
+    }
+  }
 });
 
 const headerSection = css({
@@ -233,13 +240,10 @@ const postTitle = css({
   lineHeight: "130%",
   letterSpacing: "-0.4px",
   color: "#0F0F0F",
-  transition: "colors 0.15s ease-in-out",
   overflow: "hidden",
   textOverflow: "ellipsis",
   whiteSpace: "nowrap",
-  _hover: {
-    color: "rgb(55, 65, 81)"
-  }
+  transition: "color 0.2s"
 });
 
 const contentPreview = css({

--- a/fundamentals/today-i-learned/src/components/features/discussions/WeeklyTop5.tsx
+++ b/fundamentals/today-i-learned/src/components/features/discussions/WeeklyTop5.tsx
@@ -54,13 +54,7 @@ function PopularPostItem({ post, rank }: { post: any; rank: number }) {
         </div>
 
         <h4 className={postTitle}>{post.title}</h4>
-
-        <div className={postPreview}>
-          <MarkdownRenderer
-            content={truncateMarkdown(post.body, 100)}
-            className={markdownContent}
-          />
-        </div>
+        <p className={contentPreview}>{post.body}</p>
       </button>
     </div>
   );
@@ -125,6 +119,7 @@ export function WeeklyTop5() {
 const weeklyTop5Container = css({
   display: "flex",
   flexDirection: "column",
+  padding: "1rem",
   gap: "1.5rem"
 });
 
@@ -176,23 +171,24 @@ const rankNumber = css({
 });
 
 const postButton = css({
-  flex: 1,
+  position: "relative",
   display: "flex",
   flexDirection: "column",
-  justifyContent: "flex-end",
+  justifyContent: "space-between",
+  width: "100%",
   paddingY: "1.25rem",
   paddingX: "1.5rem",
   backgroundColor: "white",
   border: "1px solid rgba(209, 213, 219, 0.5)",
   borderRadius: "1rem",
-  transition: "all 0.2s",
   textAlign: "left",
-  minHeight: "136px",
-  position: "relative",
+  transition: "all 0.2s",
+  overflow: "hidden",
   cursor: "pointer",
   _hover: {
     "& h4": {
-      color: "rgb(55, 65, 81)"
+      color: "#0064FF",
+      opacity: 0.8
     }
   }
 });
@@ -201,7 +197,7 @@ const authorSection = css({
   display: "flex",
   alignItems: "center",
   gap: "0.375rem",
-  marginBottom: "0.75rem"
+  marginBottom: "1rem"
 });
 
 const avatarStyle = css({
@@ -211,7 +207,7 @@ const avatarStyle = css({
 const authorName = css({
   fontSize: "16px",
   fontWeight: "bold",
-  color: "rgba(0, 0, 0, 0.6)",
+  color: "rgba(0, 0, 0, 0.8)",
   letterSpacing: "-0.025em",
   overflow: "hidden",
   textOverflow: "ellipsis",
@@ -219,30 +215,33 @@ const authorName = css({
 });
 
 const postTitle = css({
+  marginBottom: "0.5rem",
+  overflow: "hidden",
+
   fontWeight: "bold",
   fontSize: "18px",
   color: "#0F0F0F",
   lineHeight: "tight",
   letterSpacing: "-0.025em",
-  transition: "color 0.2s",
-  overflow: "hidden",
   textOverflow: "ellipsis",
   whiteSpace: "nowrap",
-  marginBottom: "0.75rem"
+
+  transition: "color 0.2s"
 });
 
-const postPreview = css({
+const contentPreview = css({
+  display: "-webkit-box",
   overflow: "hidden",
-  textOverflow: "ellipsis",
-  whiteSpace: "nowrap"
-});
 
-const markdownContent = css({
   fontSize: "16px",
   fontWeight: "medium",
   color: "rgba(0, 0, 0, 0.8)",
   lineHeight: "relaxed",
-  letterSpacing: "-0.025em"
+  letterSpacing: "-0.025em",
+  WebkitLineClamp: 2,
+  // @ts-ignore
+  WebkitBoxOrient: "vertical",
+  whiteSpace: "normal"
 });
 
 // Loading and Empty States

--- a/fundamentals/today-i-learned/src/components/shared/ShareLinkButton.tsx
+++ b/fundamentals/today-i-learned/src/components/shared/ShareLinkButton.tsx
@@ -1,6 +1,7 @@
-import { Link } from "lucide-react";
+import { Check, Link } from "lucide-react";
 import { useToast } from "@/contexts/ToastContext";
 import { css, cx } from "@styled-system/css";
+import { useState } from "react";
 
 const shareButton = {
   display: "flex",
@@ -21,8 +22,6 @@ const shareIconContainer = {
 const shareIcon = {
   width: "100%",
   height: "100%",
-  stroke: "#979797",
-  strokeWidth: "1.67px",
   fill: "none"
 };
 
@@ -35,14 +34,25 @@ export function ShareLinkButton({
   discussionId,
   className = ""
 }: ShareLinkButtonProps) {
-  const { success: showSuccessToast } = useToast();
+  const [isCopied, setIsCopied] = useState(false);
+  const { addToast } = useToast();
 
   const handleCopyLink = (e: React.MouseEvent) => {
+    setIsCopied(true);
     e.stopPropagation();
+
     const origin = typeof window !== "undefined" ? window.location.origin : "";
     const url = `${origin}/today-i-learned/post/${discussionId}`;
     navigator.clipboard.writeText(url);
-    showSuccessToast("링크가 복사되었습니다!");
+    addToast({
+      type: "success",
+      title: "링크가 복사되었습니다!",
+      duration: 3000
+    });
+
+    setTimeout(() => {
+      setIsCopied(false);
+    }, 3000);
   };
 
   return (
@@ -52,7 +62,11 @@ export function ShareLinkButton({
       aria-label="링크 복사"
     >
       <div className={css(shareIconContainer)}>
-        <Link className={css(shareIcon)} />
+        {isCopied ? (
+          <Check className={css(shareIcon)} stroke="#10b981" />
+        ) : (
+          <Link className={css(shareIcon)} stroke="#979797" />
+        )}
       </div>
     </button>
   );

--- a/fundamentals/today-i-learned/src/components/shared/layout/Layout.tsx
+++ b/fundamentals/today-i-learned/src/components/shared/layout/Layout.tsx
@@ -24,6 +24,6 @@ const layoutContainer = css({
 const mainContent = css({
   height: "100vh",
   paddingTop: "4.6875rem",
-  paddingLeft: "3.125rem",
+  paddingLeft: { base: 0, lg: "3.125rem" },
   overflow: "hidden"
 });

--- a/fundamentals/today-i-learned/src/components/shared/layout/Layout.tsx
+++ b/fundamentals/today-i-learned/src/components/shared/layout/Layout.tsx
@@ -21,11 +21,6 @@ const layoutContainer = css({
 });
 
 const mainContent = css({
-  paddingTop: "81px",
-  marginX: "auto",
-  minWidth: "48rem",
-  maxWidth: "1440px",
-  "@media (min-width: 1024px)": {
-    paddingLeft: "50px"
-  }
+  marginTop: "4.6875rem",
+  marginLeft: "3.125rem"
 });

--- a/fundamentals/today-i-learned/src/components/shared/layout/Layout.tsx
+++ b/fundamentals/today-i-learned/src/components/shared/layout/Layout.tsx
@@ -17,10 +17,13 @@ const layoutContainer = css({
   minHeight: "100vh",
   backgroundColor: "white",
   fontFamily: "sans-serif",
-  fontSmoothing: "antialiased"
+  fontSmoothing: "antialiased",
+  overflow: "hidden"
 });
 
 const mainContent = css({
-  marginTop: "4.6875rem",
-  marginLeft: "3.125rem"
+  height: "100vh",
+  paddingTop: "4.6875rem",
+  paddingLeft: "3.125rem",
+  overflow: "hidden"
 });

--- a/fundamentals/today-i-learned/src/components/shared/ui/InteractionButtons.tsx
+++ b/fundamentals/today-i-learned/src/components/shared/ui/InteractionButtons.tsx
@@ -1,4 +1,4 @@
-import { Heart, MessageCircle, ChevronUp } from "lucide-react";
+import { Heart, MessageCircle, ArrowUp } from "lucide-react";
 import { useState, useCallback, useEffect } from "react";
 import { Avatar } from "@/components/shared/ui/Avatar";
 import { ReactionTooltip } from "@/components/shared/ui/ReactionTooltip";
@@ -36,17 +36,11 @@ const iconContainer = {
 };
 
 const buttonText = {
+  height: "16px",
   fontSize: "16px",
+  fontWeight: "600",
   lineHeight: "130%",
-  letterSpacing: "-0.4px",
-  fontWeight: "600"
-};
-
-const upvoteText = {
-  fontSize: "16px",
-  lineHeight: "130%",
-  letterSpacing: "-0.4px",
-  fontWeight: "700"
+  letterSpacing: "-0.4px"
 };
 
 const avatarGroup = {
@@ -245,11 +239,10 @@ export function InteractionButtons({
           }}
         >
           <div className={css(iconContainer)}>
-            <ChevronUp
+            <ArrowUp
               style={{
                 width: "100%",
                 height: "100%",
-                strokeWidth: "1.67px",
                 stroke: optimisticState.hasUserUpvoted
                   ? "#979797"
                   : isCardVariant
@@ -259,7 +252,7 @@ export function InteractionButtons({
             />
           </div>
           <span
-            className={css(upvoteText)}
+            className={css(buttonText)}
             style={{
               color: optimisticState.hasUserUpvoted
                 ? "#979797"
@@ -318,7 +311,7 @@ export function InteractionButtons({
               style={{
                 width: "100%",
                 height: "100%",
-                strokeWidth: "1.67px",
+                strokeWidth: "2px",
                 stroke: optimisticState.hasUserLiked
                   ? "#979797"
                   : isCardVariant
@@ -383,7 +376,6 @@ export function InteractionButtons({
                 width: "100%",
                 height: "100%",
                 stroke: isCardVariant ? "#979797" : "rgba(0,0,0,0.4)",
-                strokeWidth: "1.67px",
                 fill: "none"
               }}
             />

--- a/fundamentals/today-i-learned/src/pages/post/PostDetailPage.tsx
+++ b/fundamentals/today-i-learned/src/pages/post/PostDetailPage.tsx
@@ -14,8 +14,8 @@ export function PostDetailPage() {
   });
 
   return (
-    <div className={pageContainer}>
-      <div className={mainContent}>
+    <div className={gridLayout}>
+      <section className={mainContentColumn}>
         {(() => {
           if (isLoading) {
             return <LoadingState />;
@@ -34,14 +34,11 @@ export function PostDetailPage() {
             />
           );
         })()}
-      </div>
+      </section>
 
-      {/* 사이드바 */}
-      <div className={sidebar}>
-        <div className={sidebarContent}>
-          <WeeklyTop5 />
-        </div>
-      </div>
+      <section className={sidebarColumn}>
+        <WeeklyTop5 />
+      </section>
     </div>
   );
 }
@@ -69,31 +66,30 @@ function ErrorState() {
 }
 
 // Semantic style definitions
-const pageContainer = css({
-  display: "flex"
+const gridLayout = css({
+  display: "grid",
+  gridTemplateColumns: { base: "1fr", lg: "5fr 3fr" },
+  height: "100%",
+  backgroundColor: "white",
+  overflow: "hidden"
 });
 
-const mainContent = css({
-  flex: "1",
-  padding: "24px",
-  "@media (min-width: 1024px)": {
-    borderLeft: "1px solid #e5e7eb",
-    borderRight: "1px solid #e5e7eb"
-  }
+const mainContentColumn = css({
+  display: "flex",
+  flexDirection: "column",
+  padding: "1.5rem",
+  borderLeft: { lg: "1px solid rgba(201, 201, 201, 0.4)" },
+  borderRight: { lg: "1px solid rgba(201, 201, 201, 0.4)" },
+  height: "100%",
+  overflowY: "auto",
+  scrollbarWidth: "none"
 });
 
-const sidebar = css({
-  width: "350px",
-  display: "none",
-  "@media (min-width: 1024px)": {
-    display: "block"
-  }
-});
-
-const sidebarContent = css({
-  position: "sticky",
-  top: "120px",
-  padding: "24px"
+const sidebarColumn = css({
+  display: { base: "none", lg: "block" },
+  paddingBottom: "2rem",
+  overflowY: "auto",
+  scrollbarWidth: "none"
 });
 
 const loadingContainer = css({

--- a/fundamentals/today-i-learned/src/pages/timeline/TimelinePage.tsx
+++ b/fundamentals/today-i-learned/src/pages/timeline/TimelinePage.tsx
@@ -146,7 +146,7 @@ const filterSection = css({
 });
 
 const postListSection = css({
-  paddingX: { lg: "1.5rem" },
+  paddingX: { base: "1rem", lg: "1.5rem" },
   paddingBottom: 0
 });
 

--- a/fundamentals/today-i-learned/src/pages/timeline/TimelinePage.tsx
+++ b/fundamentals/today-i-learned/src/pages/timeline/TimelinePage.tsx
@@ -69,53 +69,47 @@ export function TimelinePage() {
 
   return (
     <div className={pageContainer}>
-      <div className={contentWrapper}>
-        <div className={mainGridLayout}>
-          <div className={mainContentColumn}>
-            {user ? (
-              <>
-                <div className={sprintChallengeSection}>
-                  <SprintChallenge />
-                </div>
-                <SectionDivider />
-                <div className={postInputSection}>
-                  <PostInput
-                    user={{
-                      login: user.login,
-                      avatarUrl: user.avatar_url
-                    }}
-                    onSubmit={handlePostSubmit}
-                    isError={createPostMutation.isError}
-                    isLoading={createPostMutation.isPending}
-                  />
-                </div>
-                <SectionDivider />
-              </>
-            ) : (
-              <>
-                <div className={unauthenticatedSection}>
-                  <UnauthenticatedState />
-                </div>
-                <SectionDivider />
-              </>
-            )}
+      <div className={mainGridLayout}>
+        <div className={mainContentColumn}>
+          {user ? (
+            <>
+              <div className={sprintChallengeSection}>
+                <SprintChallenge />
+              </div>
+              <SectionDivider />
+              <div className={postInputSection}>
+                <PostInput
+                  user={{
+                    login: user.login,
+                    avatarUrl: user.avatar_url
+                  }}
+                  onSubmit={handlePostSubmit}
+                  isError={createPostMutation.isError}
+                  isLoading={createPostMutation.isPending}
+                />
+              </div>
+            </>
+          ) : (
+            <UnauthenticatedState />
+          )}
 
-            <div className={filterSection}>
-              <FilterSection
-                sortOption={sortOption}
-                onSortChange={handleSortChange}
-              />
-            </div>
+          <SectionDivider />
 
-            <div className={postListSection}>
-              <PostList {...getPostListProps()} />
-            </div>
+          <div className={filterSection}>
+            <FilterSection
+              sortOption={sortOption}
+              onSortChange={handleSortChange}
+            />
           </div>
 
-          <div className={sidebarColumn}>
-            <div className={sidebarContent}>
-              <WeeklyTop5 />
-            </div>
+          <div className={postListSection}>
+            <PostList {...getPostListProps()} />
+          </div>
+        </div>
+
+        <div className={sidebarColumn}>
+          <div className={sidebarContent}>
+            <WeeklyTop5 />
           </div>
         </div>
       </div>
@@ -126,12 +120,6 @@ export function TimelinePage() {
 const pageContainer = css({
   minHeight: "100vh",
   backgroundColor: "white"
-});
-
-const contentWrapper = css({
-  maxWidth: "1440px",
-  margin: "0 auto",
-  paddingX: { base: 0, lg: "2rem" }
 });
 
 const mainGridLayout = css({
@@ -157,15 +145,9 @@ const postInputSection = css({
   paddingX: { lg: "1.5rem" }
 });
 
-const unauthenticatedSection = css({
-  paddingTop: "1.5rem",
-  paddingBottom: "1rem",
-  paddingX: "1.5rem"
-});
-
 const filterSection = css({
-  paddingY: "24px",
-  paddingX: "12px"
+  paddingY: "0.5rem",
+  paddingX: "1.5rem"
 });
 
 const postListSection = css({
@@ -195,6 +177,5 @@ function SectionDivider() {
 const sectionDivider = css({
   width: "100%",
   height: 0,
-  borderBottom: "1px solid rgba(201, 201, 201, 0.4)",
-  marginTop: { base: 0, lg: "1rem" }
+  borderBottom: "1px solid rgba(201, 201, 201, 0.4)"
 });

--- a/fundamentals/today-i-learned/src/pages/timeline/TimelinePage.tsx
+++ b/fundamentals/today-i-learned/src/pages/timeline/TimelinePage.tsx
@@ -68,64 +68,57 @@ export function TimelinePage() {
   };
 
   return (
-    <div className={pageContainer}>
-      <div className={mainGridLayout}>
-        <div className={mainContentColumn}>
-          {user ? (
-            <>
-              <div className={sprintChallengeSection}>
-                <SprintChallenge />
-              </div>
-              <SectionDivider />
-              <div className={postInputSection}>
-                <PostInput
-                  user={{
-                    login: user.login,
-                    avatarUrl: user.avatar_url
-                  }}
-                  onSubmit={handlePostSubmit}
-                  isError={createPostMutation.isError}
-                  isLoading={createPostMutation.isPending}
-                />
-              </div>
-            </>
-          ) : (
-            <UnauthenticatedState />
-          )}
+    <div className={gridLayout}>
+      <section className={mainContentColumn}>
+        {user ? (
+          <>
+            <div className={sprintChallengeSection}>
+              <SprintChallenge />
+            </div>
+            <SectionDivider />
+            <div className={postInputSection}>
+              <PostInput
+                user={{
+                  login: user.login,
+                  avatarUrl: user.avatar_url
+                }}
+                onSubmit={handlePostSubmit}
+                isError={createPostMutation.isError}
+                isLoading={createPostMutation.isPending}
+              />
+            </div>
+          </>
+        ) : (
+          <UnauthenticatedState />
+        )}
 
-          <SectionDivider />
+        <SectionDivider />
 
-          <div className={filterSection}>
-            <FilterSection
-              sortOption={sortOption}
-              onSortChange={handleSortChange}
-            />
-          </div>
-
-          <div className={postListSection}>
-            <PostList {...getPostListProps()} />
-          </div>
+        <div className={filterSection}>
+          <FilterSection
+            sortOption={sortOption}
+            onSortChange={handleSortChange}
+          />
         </div>
 
-        <div className={sidebarColumn}>
-          <div className={sidebarContent}>
-            <WeeklyTop5 />
-          </div>
+        <div className={postListSection}>
+          <PostList {...getPostListProps()} />
         </div>
-      </div>
+      </section>
+
+      <section className={sidebarColumn}>
+        <WeeklyTop5 />
+      </section>
     </div>
   );
 }
 
-const pageContainer = css({
-  minHeight: "100vh",
-  backgroundColor: "white"
-});
-
-const mainGridLayout = css({
+const gridLayout = css({
   display: "grid",
   gridTemplateColumns: { base: "1fr", lg: "5fr 3fr" },
-  gap: "2rem"
+  height: "100%",
+  backgroundColor: "white",
+  overflow: "hidden"
 });
 
 const mainContentColumn = css({
@@ -133,7 +126,9 @@ const mainContentColumn = css({
   flexDirection: "column",
   borderLeft: { lg: "1px solid rgba(201, 201, 201, 0.4)" },
   borderRight: { lg: "1px solid rgba(201, 201, 201, 0.4)" },
-  minWidth: { lg: "820px" }
+  height: "100%",
+  overflowY: "auto",
+  scrollbarWidth: "none"
 });
 
 const sprintChallengeSection = css({
@@ -157,17 +152,9 @@ const postListSection = css({
 
 const sidebarColumn = css({
   display: { base: "none", lg: "block" },
-  marginTop: "24px",
-  minWidth: { lg: "490px" }
-});
-
-const sidebarContent = css({
-  position: "fixed",
-  top: "100px",
-  bottom: "1rem",
-  paddingRight: "2rem",
-  width: "490px",
-  overflowY: "auto"
+  paddingBottom: "2rem",
+  overflowY: "auto",
+  scrollbarWidth: "none"
 });
 
 function SectionDivider() {


### PR DESCRIPTION
## Issues
- #450 

## 📝 Key Changes
- 게시글 피드, 상세 페이지에서 컨텐츠와 TOP5의 영역을 full screen으로 적용하였습니다.
- 나누어진 각 영역에서 스크롤이 자연스럽게 작동되도록 사용성을 개선하였습니다.
- 변경된 layout에 따른 mobile 대응을 진행하였습니다.
- 비로그인 상태 영역 문구를 변경하고 가운데 정렬로 수정하였습니다.
- 피드 페이지의 PostCard의 style을 figma에 맞게 수정하였습니다.

## 🖼️ Before and After Comparison
| **Before** | **After** |
| ---------- | --------- |
| <img width="2032" height="1161" alt="스크린샷 2025-09-29 03 18 31" src="https://github.com/user-attachments/assets/2c9b7771-3ee7-46a1-a6a9-4915615307cd" /> | <img width="2032" height="1161" alt="스크린샷 2025-09-29 03 18 35" src="https://github.com/user-attachments/assets/56dfef6e-1824-4fd0-94d7-8110644ee3f0" /> 
| <video src="https://github.com/user-attachments/assets/364cca31-083a-4e02-ab7e-ff79d23cab7f" /> | <video src="https://github.com/user-attachments/assets/e01902a4-db34-4631-bd3d-8005a7a6393d" /> 
| <video src="https://github.com/user-attachments/assets/4cae38cd-c1c8-468a-8666-cf59188ae3b7" /> | <video src="https://github.com/user-attachments/assets/9ba00bd1-45d0-483f-911b-1f0908333771" /> |


## ETC
- hover 시의 색을 toss brand color와 opacity로 수정하였습니다.
- 게시글 링크 복사 시 icon이 변경되어 feedback을 인지할 수 있게 수정하였습니다.