### PR TITLE
fix: resolve 404 error for site.webmanifest by correcting the manifes…

### DIFF
--- a/fundamentals/code-quality/.vitepress/shared.mts
+++ b/fundamentals/code-quality/.vitepress/shared.mts
@@ -19,11 +19,11 @@ export const shared = defineConfig({
       {
         rel: "icon",
         type: "image/x-icon",
-        href: "/code-quality/images/favicon.ico"
+        href: "images/favicon.ico"
       }
     ],
-    ["link", { rel: "manifest", href: "/images/site.webmanifest" }],
-    ["link", { rel: "apple-touch-icon", href: "/images/apple-touch-icon.png" }],
+    ["link", { rel: "manifest", href: "images/site.webmanifest" }],
+    ["link", { rel: "apple-touch-icon", href: "images/apple-touch-icon.png" }],
     [
       "link",
       {
@@ -86,7 +86,7 @@ export const shared = defineConfig({
   },
 
   themeConfig: {
-    logo: "/images/ff-symbol.svg",
+    logo: "images/ff-symbol.svg",
     editLink: {
       pattern:
         "https://github.com/toss/frontend-fundamentals/edit/main/fundamentals/code-quality/:path"


### PR DESCRIPTION
## 📝 Key Changes

**English**
- Fixed a 404 error caused by an incorrect path reference to `site.webmanifest`.
- Updated the manifest URL to match the correct subdirectory structure (`/code-quality/images/site.webmanifest`).
- Verified locally that the manifest file now loads correctly without any missing resource errors.

**Korean**
- `site.webmanifest` 경로 참조 오류로 발생하던 **404 에러**를 수정했습니다.
- manifest URL을 올바른 하위 디렉토리 구조(`/code-quality/images/site.webmanifest`)에 맞게 업데이트했습니다.
- 로컬(`http://localhost:5173/code-quality/images/site.webmanifest`)에서 정상적으로 manifest 파일이 로드되는 것을 확인했습니다. (누락된 리소스 없음)

## 🖼️ Before and After Comparison

| **Before** | **After** |
|:-:|:-:|
| ![Before](https://github.com/user-attachments/assets/4b8446cd-77b5-4801-970d-b220b03953b0) | ![After](https://github.com/user-attachments/assets/05b273e2-e7b8-40c6-941d-cce355f112f5) |
