### PR TITLE
typo: 디버깅 문서(pure.md) 오타 수정

### DIFF
--- a/fundamentals/debug/pages/fix/pure.md
+++ b/fundamentals/debug/pages/fix/pure.md
@@ -76,7 +76,7 @@ react의 hook예시도 들어볼게요. 모달을 보여주는 로직이에요.
 
 ### 기존코드
 
-`localStorage`, `isTodayShown`등과 같은 여러 로직이 `useEffect` 내부에 흩어져 있어 모듈화되어 있지 않아요. 그래서 가독성도 떨어지고, 테스트도 어려워요3.
+`localStorage`, `isTodayShown`등과 같은 여러 로직이 `useEffect` 내부에 흩어져 있어 모듈화되어 있지 않아요. 그래서 가독성도 떨어지고, 테스트도 어려워요.
 
 ```tsx
 const STORAGE_KEY = "notification-modal-shownAt";


### PR DESCRIPTION
## 📝 Key Changes

문장 끝에 불필요하게 붙은 숫자(3)를 제거했습니다. 

변경 파일 [fundamentals/debug/pages/fix/pure.md](https://github.com/toss/frontend-fundamentals/blob/main/fundamentals/debug/pages/fix/pure.md?plain=1#L79)

변경 전 
- localStorage, isTodayShown등과 같은 여러 로직이 useEffect 내부에 흩어져 있어 모듈화되어 있지 않아요. 그래서 가독성도 떨어지고, 테스트도 **어려워요3.**

변경 후
- localStorage, isTodayShown등과 같은 여러 로직이 useEffect 내부에 흩어져 있어 모듈화되어 있지 않아요. 그래서 가독성도 떨어지고, 테스트도 **어려워요.**

<!-- Describe the purpose of this PR and the problem it resolves. -->

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
| ...테스트도 어려워요3. | ...테스트도 어려워요. |