### PR TITLE
chore: add favicon and header logo icon in debug documentation

### DIFF
--- a/fundamentals/debug/.vitepress/config.mts
+++ b/fundamentals/debug/.vitepress/config.mts
@@ -152,7 +152,7 @@ export default defineConfig({
       {
         rel: "icon",
         type: "image/x-icon",
-        href: "/bundling/images/favicon.ico"
+        href: "/debug/images/favicon.ico"
       }
     ],
     [

--- a/fundamentals/debug/.vitepress/shared.mts
+++ b/fundamentals/debug/.vitepress/shared.mts
@@ -72,6 +72,7 @@ export const sharedConfig = defineConfig({
   },
 
   themeConfig: {
+    logo: "/images/ff-symbol.svg",
     socialLinks: [
       { icon: "github", link: "https://github.com/toss/frontend-fundamentals" }
     ],


### PR DESCRIPTION
## 📝 Key Changes

Added a favicon and header logo icon following the debug documentation guidelines.  
This enhances the branding consistency across the app.

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
|<img width="1257" height="457" alt="스크린샷 2025-10-14 오전 10 28 40" src="https://github.com/user-attachments/assets/9cf5edfd-5de5-463c-8c12-a7c7cc17d1e7" />| <img width="1264" height="463" alt="스크린샷 2025-10-14 오전 10 28 28" src="https://github.com/user-attachments/assets/05605126-e274-43bf-beee-0ff691217167" />|