### PR TITLE
fix: Remove unnecessary <base> tag causing relative link routing issues  

### DIFF
--- a/fundamentals/code-quality/.vitepress/shared.mts
+++ b/fundamentals/code-quality/.vitepress/shared.mts
@@ -80,7 +80,6 @@ export const shared = defineConfig({
 
     head.push(["meta", { property: "og:title", content: title }]);
     head.push(["meta", { property: "og:description", content: description }]);
-    head.push(["base", { href: "/code-quality/" }]);
 
     return head;
   },


### PR DESCRIPTION
## 📝 Key Changes

Fixes #495 , #576 
  
This PR removes the `<base>` tag injection from the `transformHead` function in `shared.mts` that was causing relative links to break in production builds.  
  
**Problem:**  
When clicking relative links like `./examples/submit-button.html` from `/code-quality/code/`, the browser incorrectly navigates to `/code-quality/examples/submit-button.html` instead of the expected `/code-quality/code/examples/submit-button.html`.  
  
**Root Cause:**  
The HTML `<base>` tag forces all relative paths to resolve from `/code-quality/`, overriding the current page's path. This conflicts with VitePress's client-side routing, which already handles base path configuration correctly.  
  
**Solution:**  
Remove the manual `<base>` tag injection from `transformHead`. VitePress's built-in `base` configuration is sufficient for proper routing without the need for an explicit HTML `<base>` tag.  

## 🖼️ Before and After Comparison  

| Before | After |
|:------:|:-----:|
| ![전](https://github.com/user-attachments/assets/add57ff8-21f9-4bbb-92ca-2e2479f9c0ce)|![후](https://github.com/user-attachments/assets/7a6d0d1f-6d0a-4bb7-8cb9-3a7326b651e6)|



