### PR TITLE
docs: Fix code block language settings and highlighting

### DIFF
--- a/fundamentals/bundling/webpack-tutorial/environment.md
+++ b/fundamentals/bundling/webpack-tutorial/environment.md
@@ -31,7 +31,7 @@ npm install --save-dev dotenv-webpack
 
 `.env` 파일 예시:
 
-```env
+```dotenv
 # API 설정
 API_URL=https://api.example.com
 API_KEY=your-api-key
@@ -108,7 +108,7 @@ const App: React.FC = () => {
    - `dotenv-webpack`의 `safe` 옵션을 사용해요
    - `.env.example` 파일에 필수 변수를 정의해요:
 
-   ```env
+   ```dotenv
    API_URL=
    API_KEY=
    DEBUG_MODE=

--- a/fundamentals/bundling/webpack-tutorial/make-first-bundle.md
+++ b/fundamentals/bundling/webpack-tutorial/make-first-bundle.md
@@ -113,7 +113,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
 지금까지 만들어진 파일 구조를 다시 살펴볼게요.
 
-```{6-10}
+```text{6-10}
 example-project/
 ├── index.html
 ├── style.css

--- a/fundamentals/debug/pages/fix/dead-code.md
+++ b/fundamentals/debug/pages/fix/dead-code.md
@@ -30,7 +30,7 @@ export function formatDateForChristmasEventUser(date: Date): string {
 
 `stylelint`를 사용해 사용되지 않을 선택자가 저장되는 것을 예방할 수 도 있어요. 아래와 같이 `stylelintrc` 파일에 린트를 셋팅해 두면, 선언되었지만 사용되지 않은 클래스가 있으면 워닝을 띄워줘요. 단, 런타임에만 등장하는 클래스는 **오탐/미탐** 가능성이 있어요.
 
-```cli
+```bash
 npm install --save-dev stylelint stylelint-no-unused-selectors
 ```
 


### PR DESCRIPTION
## 📝 Key Changes

This PR fixes incorrect code block language settings and missing syntax highlighting in the documentation.  

I did not modify the contents inside the `/bundling/tutorial` folder because I knew it was a [legacy document](https://github.com/toss/frontend-fundamentals/pull/300#pullrequestreview-3015435946)🙃


## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
|<img width="740" height="577" alt="스크린샷 2025-10-25 오후 8 37 51" src="https://github.com/user-attachments/assets/2bdb8784-1ef2-4c95-96eb-d46f70ba0260" />| <img width="743" height="594" alt="스크린샷 2025-10-25 오후 8 38 43" src="https://github.com/user-attachments/assets/d5a9042f-4040-443a-aa32-ed7b9cf776d8" />|

| Before | After |
|:------:|:-----:|
| <img width="731" height="466" alt="스크린샷 2025-10-25 오후 8 39 30" src="https://github.com/user-attachments/assets/44f41ff9-6c58-46b5-980c-0f4bd3183e11" />|  <img width="757" height="469" alt="스크린샷 2025-10-25 오후 8 39 36" src="https://github.com/user-attachments/assets/1f313b77-a403-4b08-ae0a-0e7ecd9bdc8b" />|


| Before | After |
|:------:|:-----:|
|  <img width="715" height="295" alt="스크린샷 2025-10-25 오후 8 41 14" src="https://github.com/user-attachments/assets/8c2cd89e-ceb1-4483-a292-69b00728892e" />| <img width="730" height="291" alt="스크린샷 2025-10-25 오후 8 41 08" src="https://github.com/user-attachments/assets/f8cdfefd-3c54-409b-bb50-c0464bed88a8" />|
