### PR TITLE
fix: Language detection by validating URL path segments  

### DIFF
--- a/fundamentals/today-i-learned/src/components/shared/layout/LayoutNavigation.tsx
+++ b/fundamentals/today-i-learned/src/components/shared/layout/LayoutNavigation.tsx
@@ -2,18 +2,29 @@ import { useLocation } from "react-router-dom";
 import { OneNavigationReact } from "@shared/components";
 import { NavigationBar } from "./NavigationBar";
 
+const SUPPORTED_LANGUAGES = ["ko", "en", "ja", "zh-hans"];
+
+const extractLanguageCode = (path: string) => {
+  const firstSegment = path.split("/")[1];
+  const isValidLanguage = SUPPORTED_LANGUAGES.includes(firstSegment);
+
+  if (isValidLanguage) {
+    return firstSegment;
+  }
+
+  return null;
+};
+
 export const LayoutNavigation: React.FC = () => {
   const location = useLocation();
-  const isKorean =
-    !location.pathname.startsWith("/en") &&
-    !location.pathname.startsWith("/ja") &&
-    !location.pathname.startsWith("/zh-hans");
+  const lang = extractLanguageCode(location.pathname) ?? "ko";
+  const isKorean = lang === "ko";
 
   return (
     <>
       <NavigationBar />
       <OneNavigationReact
-        lang={location.pathname.split("/")[1] || "ko"}
+        lang={lang}
         isKorean={isKorean}
         pathname={location.pathname}
       />


### PR DESCRIPTION
## 📝 Key Changes

Fixes: [#599](https://github.com/toss/frontend-fundamentals/issues/599)
  
Fixed language detection bug in navigation sidebar where non-language URL segments were incorrectly treated as language codes.  
  
### Problem  
- On paths like `https://frontend-fundamentals.com/today-i-learned/post/D_kwDONfHk5s4AitBU`, the `lang` prop was incorrectly set to `"post"`  
- This caused navigation links to be malformed (e.g., clicking on a11y would navigate to `/a11y/post` instead of `/a11y`)  
  
### Solution  
- Extract language segment from `location.pathname` and validate against `SUPPORTED_LANGUAGES` (`["ko", "en", "ja", "zh-hans"]`)  
- If valid language code is found, use it; otherwise default to `"ko"`  
- Implemented `extractLanguageCode()` function for centralized validation logic  
  

## 🖼️ Before and After Comparison

|**Before**|**After**|
|:-:|:-:|
| ![2025-11-0317-08-58-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/b588823d-62bf-4e7d-97e5-0d4ca79320f7)| ![2025-11-0317-09-07-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/97860fbe-7c6e-4805-8f3d-c802a5e1479c)|