### PR TITLE
fix: .md 파일이 .html로 변환되는 과정에서 발생하는 상대경로 라우팅 오류 해결

### DIFF
--- a/fundamentals/code-quality/.vitepress/shared.mts
+++ b/fundamentals/code-quality/.vitepress/shared.mts
@@ -80,7 +80,6 @@ export const shared = defineConfig({
 
     head.push(["meta", { property: "og:title", content: title }]);
     head.push(["meta", { property: "og:description", content: description }]);
-    head.push(["base", { href: "/code-quality/" }]);
 
     return head;
   },


### PR DESCRIPTION
## 📝 Key Changes

  `shared.mts`에서 `<base href="/code-quality/">` 태그를 제거하여 상대 경로 링크가 올바르게 동작하도록 수정했습니다.

  **문제 상황:**
  - `/code-quality/code/` 페이지에서 `./examples/submit-button` 링크 클릭 시
  - 예상 경로: `/code-quality/code/examples/submit-button.html`
  - 실제 이동: `/code-quality/examples/submit-button.html` (404 에러)

  **원인 분석:**
  HTML `<base>` 태그는 페이지 내 모든 상대 경로의 기준점(base URL)을 변경합니다.
  - `<base href="/code-quality/">`가 설정되어 있으면
  - 모든 상대 경로(`./`, `../`)가 현재 페이지가 아닌 `/code-quality/`를 기준으로 해석됩니다
  - 따라서 `/code-quality/code/` 에서 `./examples/submit-button`는
    - 현재 위치 기준: `/code-quality/code/` + `examples/submit-button` ✅
    - base 태그 기준: `/code-quality/` + `examples/submit-button` ❌

  **해결 방법:**
  `<base>` 태그를 제거하여 상대 경로가 현재 페이지 위치를 기준으로 정상 해석되도록 했습니다.

  ## 🔄️ Before and After Comparison

  |**Before**|**After**|
  |:-:|:-:|
  | `/code-quality/code/` 페이지에서<br>`./examples/submit-button` 클릭 시<br>→ `/code-quality/examples/submit-button.html` (404) | `/code-quality/code/`
  페이지에서<br>`./examples/submit-button` 클릭 시<br>→ `/code-quality/code/examples/submit-button.html` (✅) |


### AS-IS


https://github.com/user-attachments/assets/bc22e8b0-8265-41cc-8829-ec5cd6517b53


### TO-BE

https://github.com/user-attachments/assets/f2482d4b-211a-426d-acd0-2797ceb779bf



