### PR TITLE
docs: Add missing form section to Japanese principles documentation 

### DIFF
--- a/fundamentals/a11y/ja/principles.md
+++ b/fundamentals/a11y/ja/principles.md
@@ -21,6 +21,7 @@ HTML 要素を正しくラップし、適切に配置することがアクセシ
 見た目と実際の動作が一致している必要があります。
 
 - [ボタンの役割と動作を一致させる](./predictability/fake-button.md)
+- [入力要素は&lt &lt;form&gt; で包む](./predictability/form.md)
 
 ## 4. 🌈 視覚情報だけに依存しない
 


### PR DESCRIPTION
## 📝 Key Changes

Added a missing section about wrapping input elements in `<form>` tags to the Japanese principles documentation, aligning it with the Korean original documentation structure.  
  
### Problem  
- The Japanese principles page was missing a link to the form documentation under section 3 (Predictable Interactions)  
- This created inconsistency between the Korean and Japanese documentation  
  
### Solution  
- Added the missing link: `[入力要素は<form>で包む](./predictability/form.md)` under section 3  
- This brings the Japanese documentation in line with the Korean version which includes this section  
- Ensures complete coverage of the 4 core accessibility principles in Japanese  

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
| <img width="1389" height="644" alt="스크린샷 2025-11-11 오전 12 25 01" src="https://github.com/user-attachments/assets/85b2f2e9-c3c6-44da-94ae-1d76bba75a35" />| <img width="1385" height="675" alt="스크린샷 2025-11-11 오전 12 25 27" src="https://github.com/user-attachments/assets/655da15b-de2d-4af1-9ce1-a588a43c853d" /> |

