### PR TITLE
fix(a11y): prevent path corruption when switching languages on 404 pages

### DIFF
--- a/fundamentals/a11y/.vitepress/theme/Layout.vue
+++ b/fundamentals/a11y/.vitepress/theme/Layout.vue
@@ -3,9 +3,37 @@ import DefaultTheme from "vitepress/theme";
 import Comments from "./components/Comments.vue";
 import OneNavigation from "@shared/components/OneNavigation.vue";
 import { useLocale } from "./hooks";
+import { onMounted } from "vue";
+import { useRoute } from "vitepress";
 
 const { Layout } = DefaultTheme;
 const { isKorean } = useLocale();
+const route = useRoute();
+
+onMounted(() => {
+  document.addEventListener("click", (e) => {
+    const target = e.target as HTMLElement;
+    const link = target.closest('a[href^="/a11y/"]');
+
+    if (link?.classList.value === "VPLink link") {
+      e.preventDefault();
+
+      const href = link.getAttribute("href");
+      const targetLangMatch = href?.match(/^\/a11y\/(en|ja|zh-hans)\//);
+      const targetLang = targetLangMatch ? targetLangMatch[1] : "ko";
+
+      const pathWithoutLang = route.path
+        .replace(/^\/a11y\/(en|ja|zh-hans)\//, "/a11y/")
+        .replace(/^\/a11y\//, "");
+      const newPath =
+        targetLang === "ko"
+          ? `/a11y/${pathWithoutLang}`
+          : `/a11y/${targetLang}/${pathWithoutLang}`;
+
+      window.location.href = newPath;
+    }
+  });
+});
 </script>
 
 <template>


### PR DESCRIPTION
## 📝 Key Changes

This PR fixes a bug where language switching from a 404 page causes URL path corruption in the **A11y Fundamentals documentation** (`/a11y/` path).  
  
### Problem  
When navigating through the following sequence in the A11y documentation:  
1. Visit `/a11y/structure/button-inside-button.html` (Korean)  
2. Switch to English (page doesn't exist → 404)  
3. Switch back to Korean  
4. Result: `/a11y/y/en/structure/button-inside-button.html` (corrupted path)    
  
### Solution  
Added a custom click event handler in the A11y documentation's `Layout.vue` that intercepts language switch clicks and reconstructs the URL correctly by:  
1. Extracting the language-agnostic page path from the current URL  
2. Identifying the target language from the clicked link  
3. Reconstructing the complete path with the correct language prefix  
  
This ensures that language switching works correctly even from 404 pages, preventing path corruption.  

## 🖼️ Before and After Comparison

Select language : `ko` ➔ `en` ➔ `ko`

|**Before**|**After**|
|:-:|:-:|
| ![2025-11-1116-35-11-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/9a3ae85e-ee8c-4966-b031-fdea5b814b09)| ![2025-11-1116-34-53-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/df70a6d8-0ab8-461a-9ebc-7ce90bfe825d) |

