### PR TITLE
Fix incorrect useQueryParam setter example in use-page-state-readability.md

### DIFF
--- a/fundamentals/code-quality/code/examples/use-page-state-readability.md
+++ b/fundamentals/code-quality/code/examples/use-page-state-readability.md
@@ -90,8 +90,8 @@ export function useCardIdQueryParam() {
   const [cardId, _setCardId] = useQueryParam("cardId", NumberParam);
 
   const setCardId = useCallback((cardId: number) => {
-    _setCardId({ cardId }, "replaceIn");
-  }, []);
+    _setCardId(cardId, "replaceIn");
+  }, [_setCardId]);
 
   return [cardId ?? undefined, setCardId] as const;
 }


### PR DESCRIPTION
## 📝 Key Changes

<!-- Describe the purpose of this PR and the problem it resolves. -->

The example in `use-page-state-readability.md` incorrectly passed an object to the `useQueryParam` setter:

```typescript
_setCardId({ cardId }, "replaceIn");
```

This PR updates the example to use the correct usage:

```typescript
_setCardId(cardId, "replaceIn");
```
This fixes misleading documentation and aligns the example with the expected API of useQueryParam.

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
|`_setCardId({ cardId }, "replaceIn");`|`_setCardId(cardId, "replaceIn");`|