### PR TITLE
fix(code-quality): correct favicon path to load properly in deep routes

### DIFF
--- a/fundamentals/code-quality/.vitepress/shared.mts
+++ b/fundamentals/code-quality/.vitepress/shared.mts
@@ -19,7 +19,7 @@ export const shared = defineConfig({
       {
         rel: "icon",
         type: "image/x-icon",
-        href: "images/favicon.ico"
+        href: "/code-quality/images/favicon.ico"
       }
     ],
     ["link", { rel: "manifest", href: "images/site.webmanifest" }],


### PR DESCRIPTION
## 📝 Key Changes

Fixed an issue where the favicon was not loading correctly due to inconsistent path resolution in deep routes.

### Problem
- A relative path such as `"images/favicon.ico" ` was used while `base: "/code-quality/"` was configured.
- In practice, the resolved path differed depending on the current route:
  - At the root (`/code-quality/`), it attempted to load `/code-quality/images/favicon.ico` → _failed_
  - In deeper routes such as `/code-quality/code/detail`, it attempted to load `/code-quality/code/images/favicon.ico` → _successful_
- This inconsistent behavior caused the favicon to fail loading in certain routes.

### Problem
- Updated only the favicon path in the head array of shared.mts to an absolute path that includes the base path.
- Changed: `href: "images/favicon.ico"` → `href: "/code-quality/images/favicon.ico"`

<!-- Describe the purpose of this PR and the problem it resolves. -->

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
| `href: "images/favicon.ico"`| `href: "/code-quality/images/favicon.ico"`|
| Favicon failed to load at `/code-quality/`| Favicon loads correctly at all routes|

### Before

<img width="4892" height="1354" alt="image" src="https://github.com/user-attachments/assets/1dfcaee9-08d1-4efe-9c8f-ee6826dadee2" />


### After

<img width="2446" height="677" alt="image" src="https://github.com/user-attachments/assets/5fc5e9a1-5c9b-4574-a418-40ad062a5349" />
