### PR TITLE
fix: correct bundle-analyzer link in overview

### DIFF
--- a/fundamentals/bundling/deep-dive/overview.md
+++ b/fundamentals/bundling/deep-dive/overview.md
@@ -38,4 +38,4 @@
 
 2. [트리셰이킹](../deep-dive/optimization/tree-shaking): 실제로 사용하지 않는 코드를 분석하고 제거하여 번들 크기를 줄여요.
 
-3. [번들 분석](../deep-dive/optimization/code-splitting): 번들 결과물을 시각적으로 분석하여 어떤 모듈이 용량을 많이 차지하는지 파악하고 개선 방향을 찾아요.
+3. [번들 분석](../deep-dive/optimization/bundle-analyzer): 번들 결과물을 시각적으로 분석하여 어떤 모듈이 용량을 많이 차지하는지 파악하고 개선 방향을 찾아요.


### PR DESCRIPTION
## 📝 Key Changes

<!-- Describe the purpose of this PR and the problem it resolves. -->

Fixes: #731 

Fixed the "번들 분석" link in the deep-dive overview page that was incorrectly pointing to the `code-splitting` page. Updated the link to point to the correct `bundle-analyzer` page.

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
| ![1](https://github.com/user-attachments/assets/64e4eccf-3428-4116-9089-842a5cdf67ae)|![2](https://github.com/user-attachments/assets/48dc3409-cfd8-45ac-84bf-e48d558e82c5) |