### PR TITLE
fix: correct tabindex syntax in form examples

### DIFF
--- a/fundamentals/a11y/ja/predictability/form.md
+++ b/fundamentals/a11y/ja/predictability/form.md
@@ -75,7 +75,7 @@
   <div>
     <input id="login-id" name="id" type="text" />
     <!-- 入力値があるときだけ表示される削除ボタン -->
-    <button type="button" tabindex="{-1}" aria-label="ID の入力値を削除">
+    <button type="button" tabindex="-1" aria-label="ID の入力値を削除">
       ❌
     </button>
   </div>

--- a/fundamentals/a11y/predictability/form.md
+++ b/fundamentals/a11y/predictability/form.md
@@ -72,7 +72,7 @@
   <div>
     <input id="login-id" name="id" type="text" />
     <!-- 입력값이 있을 때만 보이는 삭제 버튼 -->
-    <button type="button" tabindex="{-1}" aria-label="아이디 입력값 삭제">
+    <button type="button" tabindex="-1" aria-label="아이디 입력값 삭제">
       ❌
     </button>
   </div>


### PR DESCRIPTION
## 📝 Key Changes

<!-- Describe the purpose of this PR and the problem it resolves. -->

Fixes: #735 

Fixed invalid tabindex syntax in the form accessibility examples. Changed `tabindex="{-1}"` (JSX/template syntax) to `tabindex="-1"` (valid HTML syntax). 
The same file already uses the correct syntax in the password field example, so I updated the ID field example to match.

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
| <img width="1168" height="833" alt="image" src="https://github.com/user-attachments/assets/e6b7d3da-2d50-46c0-934e-ad36e6f1900e" /> | <img width="1182" height="895" alt="image" src="https://github.com/user-attachments/assets/90280fde-ea7d-4ce1-94ac-bd3a36e5e5c6" /> |