### PR TITLE
fix(a11y): resolve language switching issues in A11y documentation  

### DIFF
--- a/fundamentals/a11y/.vitepress/theme/Layout.vue
+++ b/fundamentals/a11y/.vitepress/theme/Layout.vue
@@ -4,18 +4,19 @@ import Comments from "./components/Comments.vue";
 import OneNavigation from "@shared/components/OneNavigation.vue";
 import { useLocale } from "./hooks";
 import { onMounted } from "vue";
-import { useRoute } from "vitepress";
+import { useRoute, useRouter } from "vitepress";
 
 const { Layout } = DefaultTheme;
 const { isKorean } = useLocale();
 const route = useRoute();
+const router = useRouter();
 
 onMounted(() => {
   document.addEventListener("click", (e) => {
     const target = e.target as HTMLElement;
     const link = target.closest('a[href^="/a11y/"]');
 
-    if (link?.classList.value === "VPLink link") {
+    if (link?.classList.value.startsWith("VPLink link")) {
       e.preventDefault();
 
       const href = link.getAttribute("href");
@@ -30,7 +31,10 @@ onMounted(() => {
           ? `/a11y/${pathWithoutLang}`
           : `/a11y/${targetLang}/${pathWithoutLang}`;
 
-      window.location.href = newPath;
+      // VitePress needs time to clear its internal 404 state before routing to the new path
+      setTimeout(() => {
+        router.go(newPath);
+      }, 100);
     }
   });
 });


### PR DESCRIPTION
## 📝 Key Changes  

follow-up: #669 
  
This PR fixes two critical issues with language switching in the A11y Fundamentals documentation:  
  
1. **Fixed 404 routing issue**: Replaced `window.location.href` with VitePress's `router.go()` to maintain client-side routing, ensuring custom 404 components are displayed instead of Vercel's generic 404 pages when navigating to non-existent language variants.  

<img width="1069" height="395" alt="스크린샷 2025-12-19 오후 3 54 43" src="https://github.com/user-attachments/assets/7b8bb7b0-1fd0-4d53-b9d3-e5a2bed68498" />

2. **Fixed mobile language switch detection**: Updated the language switch button detection from exact class match (`=== "VPLink link"`) to prefix match (`startsWith("VPLink link")`) to handle different class structures between PC and mobile versions.  

|**PC**|**Mobile**|
|:-:|:-:|
|<img width="655" height="82" alt="스크린샷 2025-12-19 오후 3 28 00" src="https://github.com/user-attachments/assets/04ec79e2-26f5-409f-8505-f2e64daab4b6" />| <img width="706" height="85" alt="스크린샷 2025-12-19 오후 3 28 11" src="https://github.com/user-attachments/assets/5b66f8e7-6f29-4cab-8be4-4e82297eb204" />|

### Deployment environment testing
- [Vercel Deployment Environment](https://ff-test-wo-o29.vercel.app/a11y/structure/button-inside-button.html)
![chrome-capture-2025-12-30](https://github.com/user-attachments/assets/cea8bebf-f19b-4ab9-9a38-269f162acca2)


## 💬 Comment

If you have a better solution, please feel free to suggest it

There’s a similar issue in the bundling and debugging documentation sections, so if this approach fully resolves the problem, it’d be worth applying!