### PR TITLE
fix(TIL): search results scroll and layout issues

### DIFF
--- a/fundamentals/today-i-learned/src/pages/search/SearchContent.tsx
+++ b/fundamentals/today-i-learned/src/pages/search/SearchContent.tsx
@@ -1,6 +1,6 @@
 import { useSearchDiscussions } from "@/api/hooks/useSearchDiscussions";
 import { Search } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useIntersectionObserver } from "@/hooks/useIntersectionObserver";
 import {
   PostCard,
@@ -37,6 +37,14 @@ export function SearchContent({ query }: SearchContentProps) {
     onIntersect: handleLoadMore,
     rootMargin: "300px"
   });
+
+  const resultsWrapperRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (resultsWrapperRef.current) {
+      resultsWrapperRef.current.scrollTo({ top: 0 });
+    }
+  }, [query]);
 
   if (!query) {
     return (
@@ -96,7 +104,7 @@ export function SearchContent({ query }: SearchContentProps) {
         <span className={resultCount}>({discussions.length}개)</span>
       </h1>
 
-      <div className={resultsWrapper}>
+      <div className={resultsWrapper} ref={resultsWrapperRef}>
         {discussions.map((discussion, index) => (
           <div
             key={discussion.id}
@@ -177,7 +185,18 @@ const resultCount = css({
 });
 
 const resultsWrapper = css({
-  width: "100%"
+  width: "100%",
+  height: "100vh",
+  overflowY: "auto",
+  // 1024px 이하 하단 nav바 높이 고려
+  paddingBottom: "240px",
+  lg: {
+    paddingBottom: "180px"
+  },
+  scrollbarWidth: "none",
+  "&::-webkit-scrollbar": {
+    display: "none"
+  }
 });
 
 const skeletonWithMargin = css({


### PR DESCRIPTION
## 📝 Key Changes  
  
### Scroll Functionality  
- Fixed search results not being scrollable by adding `overflow: auto` and `height: 100vh` to the results wrapper  
- Added scrollbar hiding for cleaner UI appearance  
  
### Layout Improvements    
- Applied `240px` padding-bottom for mobile (≤1024px) and `180px` for desktop to account for header and bottom navigation  
  
### Scroll Position Reset  
- Added `useEffect` with `scrollTo({ top: 0 })` to reset scroll position when search query changes  
- Implemented using `useRef` to reference the results wrapper element  

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
|![chrome-capture-2025-12-21 (1)](https://github.com/user-attachments/assets/cdb4a9ac-ece9-4d86-bac4-cfc1edaab0e7)|![chrome-capture-2025-12-21](https://github.com/user-attachments/assets/1fdb0226-69de-4f42-ae2a-9d6383f8cbcd)|