### PR TITLE
chore: remove unnecessary blank lines in vitepress config

### DIFF
--- a/fundamentals/debug/.vitepress/config.mts
+++ b/fundamentals/debug/.vitepress/config.mts
@@ -255,7 +255,6 @@ export default defineConfig({
                   {
                     text:"Radix UI Dialog 내 Select 컴포넌트 ESC 키 충돌 버그 사례",
                     link: "/pages/contribute/package/radix_ui_dialog_select_esc.md"
-                 
                   }
                 ]
               },


### PR DESCRIPTION
## 📝 Key Changes

- Removed unnecessary blank lines in `.vitepress/config.mts`
- No functional changes
- Improves readability and consistency

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
| <img width="705" height="199" alt="image" src="https://github.com/user-attachments/assets/1913267e-0582-4926-be89-785d16c3e460" />|<img width="666" height="164" alt="image" src="https://github.com/user-attachments/assets/33c7adc4-2b70-4a86-9225-036cec44d80f" /> |