### PR TITLE
fix(code-quality): add missing logo to English documentation header

### DIFF
--- a/fundamentals/code-quality/.vitepress/en.mts
+++ b/fundamentals/code-quality/.vitepress/en.mts
@@ -6,6 +6,7 @@ export const en = defineConfig({
   description: "A guide for easily modifiable frontend code",
   lastUpdated: true,
   themeConfig: {
+    logo: "/images/ff-symbol.svg",
     nav: nav(),
     editLink: {
       pattern:


### PR DESCRIPTION
## 📝 Key Changes

<!-- Describe the purpose of this PR and the problem it resolves. -->

Fixes missing logo in the English documentation header by adding logo configuration to `en.mts`.

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
| <img width="3456" height="1916" alt="image" src="https://github.com/user-attachments/assets/0dfb2a18-b7f6-476d-acc2-e52f0e278043" /> | <img width="3456" height="1916" alt="image" src="https://github.com/user-attachments/assets/68726df2-44af-465c-82e7-fa66d040d4e2" />|





