### PR TITLE
fix(code-quality): remove titleTemplate override to display site title

### DIFF
--- a/fundamentals/code-quality/.vitepress/config.mts
+++ b/fundamentals/code-quality/.vitepress/config.mts
@@ -45,13 +45,12 @@ export default defineConfig({
       ]
     },
     ssr: {
-      noExternal: ['vitepress-plugin-tabs']
+      noExternal: ["vitepress-plugin-tabs"]
     }
   },
   markdown: {
     config: (md) => {
       md.use(footnote);
     }
-  },
-  titleTemplate: ":title"
+  }
 });


### PR DESCRIPTION
## 📝 Key Changes

<!-- Describe the purpose of this PR and the problem it resolves. -->

Fixes the page title format in the code-quality documentation section to be consistent with other documentation sections (debug, a11y, bundling).

### Problem
The code-quality documentation had `titleTemplate: ":title"` configured, which prevented the site title from appearing in browser tabs and search results.

**Before:**
- Code Quality docs: `시작하기`
- Other docs: `시작하기 | Debug Fundamentals`

**After:**
- Code Quality docs: `시작하기 | Frontend Fundamentals`
- Consistent with all other documentation sections

### Changes
- Removed `titleTemplate: ":title"` from `fundamentals/code-quality/.vitepress/config.mts`
- Now uses VitePress default title template like other documentation sections


## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
| <img width="300" alt="Before" src="https://github.com/user-attachments/assets/8b951e5a-d985-4e4e-b37d-e202e82f092b" /> | <img width="300" alt="After" src="https://github.com/user-attachments/assets/7c093b2b-0309-4f33-8830-4e99fd34e03c" /> |

