### PR TITLE
fix(a11y): correct eslint-plugin-jsx-a11y package name typo

### DIFF
--- a/fundamentals/a11y/eslint/rules.md
+++ b/fundamentals/a11y/eslint/rules.md
@@ -106,7 +106,7 @@ export default [
 
 인터랙티브 요소(입력 필드, 버튼, 선택 상자 등)에는 반드시 사용자에게 그 목적을 명확히 알려주는 이름이 필요해요. 이름이 없거나 불명확한 요소는 스크린 리더 사용자나 음성 지원 사용자에게 큰 불편을 줄 수 있어요. 자세한 내용은 [인터랙티브 요소에 이름 넣기](../semantic/required-label) 문서에서 확인해 보세요.
 
-`eslint-plugin-jsx-ally` 의 recommended 룰에 기본적으로 비활성화되어 있으니, 다음과 같이 `rules` 에 직접 추가해서 활성화 해줘야 해요.
+`eslint-plugin-jsx-a11y` 의 recommended 룰에 기본적으로 비활성화되어 있으니, 다음과 같이 `rules` 에 직접 추가해서 활성화 해줘야 해요.
 
 :::tabs key:bundler-object-entry
 == flat config

--- a/fundamentals/a11y/ja/eslint/rules.md
+++ b/fundamentals/a11y/ja/eslint/rules.md
@@ -106,7 +106,7 @@ export default [
 
 インタラクティブ要素（入力フィールド、ボタン、セレクトなど）には、目的をユーザーに明確に伝える名前が必須です。名前がない／不明確な要素は、スクリーンリーダー利用者や音声アシスタント利用者に大きな不便を与えます。詳しくは[インタラクティブ要素に名前を付ける](../semantic/required-label)を参照してください。
 
-`eslint-plugin-jsx-ally`の recommendedではこのルールは既定で無効なので、次のように`rules`に明示的に追加して有効化してください。
+`eslint-plugin-jsx-a11y`の recommendedではこのルールは既定で無効なので、次のように`rules`に明示的に追加して有効化してください。
 
 :::tabs key:bundler-object-entry
 == flat config


### PR DESCRIPTION
## 📝 Key Changes

<!-- Describe the purpose of this PR and the problem it resolves. -->

Fixes a typo in the 'eslint-plugin-jsx-a11y' package name in the accessibility documentation.
- Before: `eslint-plugin-jsx-ally`
- After: `eslint-plugin-jsx-a11y`