### PR TITLE
fix(shared): move tooltip above bottom navigation to prevent click interference

### DIFF
--- a/fundamentals/shared/components/styles/OneNavigation.css
+++ b/fundamentals/shared/components/styles/OneNavigation.css
@@ -141,4 +141,17 @@
     height: 2px;
     width: calc(100% - 16px);
   }
+
+  .nav-item[data-tooltip]::after {
+    left: 50%;
+    top: auto;
+    bottom: 100%;
+    transform: translateX(-50%);
+    margin-bottom: 8px;
+  }
+
+  .nav-item[data-tooltip]:hover::after {
+    left: 50%;
+    bottom: calc(100% + 4px);
+  }
 }

--- a/fundamentals/shared/components/styles/OneNavigation.css
+++ b/fundamentals/shared/components/styles/OneNavigation.css
@@ -152,6 +152,6 @@
 
   .nav-item[data-tooltip]:hover::after {
     left: 50%;
-    bottom: calc(100% + 4px);
+    bottom: calc(100% + 8px);
   }
 }


### PR DESCRIPTION
## 📝 Key Changes
Fixed an issue where tooltips on bottom navigation buttons were blocking user clicks when the screen width is reduced below 1024px.
<img src="https://github.com/user-attachments/assets/5e7b4e55-1dc4-4e29-9791-c21bcfb0eea3" width="400">

### Problem
- When the screen width is below 1024px, the navigation transforms from a sidebar to a bottom navigation bar
- Tooltips continued to use desktop positioning (appearing to the right of buttons)
- This caused the tooltips to overlap with the clickable area of the buttons
- **Users couldn't click buttons when tooltips were visible**

### Solution
Added responsive tooltip positioning in \`OneNavigation.css\` for screens below 1024px:
- Changed tooltip position to appear above buttons instead of to the right
- Centered tooltip horizontally with \`left: 50%\` and \`transform: translateX(-50%)\`
- Added 8px margin between button and tooltip for better spacing
- Adjusted hover state to maintain consistent positioning

## 🖼️ Before and After Comparison

| Before | After |
|--------|-------|
| Tooltip uses desktop positioning (right side) | Tooltip appears above button |
| Tooltip blocks button clicks | Button remains clickable |
| Poor UX on narrow screens | Improved UX on narrow screens |

### Before
<img width="792" height="58" alt="image" src="https://github.com/user-attachments/assets/2e2b5c76-571a-4083-9a08-42615e0d3d78" />

### After
<img width="792" height="87" alt="image" src="https://github.com/user-attachments/assets/57275cbd-9056-42ac-a796-40685bafbfd8" />


### CSS Changes
```css
/* Added responsive tooltip positioning for screens below 1024px */
@media (max-width: 1024px) {
  .nav-item[data-tooltip]::after {
    left: 50%;
    top: auto;
    bottom: 100%;
    transform: translateX(-50%);
    margin-bottom: 8px;
  }

  .nav-item[data-tooltip]:hover::after {
    left: 50%;
    bottom: calc(100% + 4px);
  }
}
```

This change ensures that tooltips enhance UX rather than hinder it when the navigation switches to bottom bar mode."