### PR TITLE
feat: Localize switch label for mobile navigation

### DIFF
--- a/fundamentals/a11y/.vitepress/config.mts
+++ b/fundamentals/a11y/.vitepress/config.mts
@@ -19,7 +19,10 @@ export default defineConfig({
     en: {
       label: "English",
       lang: "en",
-      themeConfig: { nav: [{ text: "Home", link: "/en/" }] }
+      themeConfig: {
+        nav: [{ text: "Home", link: "/en/" }],
+        darkModeSwitchLabel: "Appearance"
+      }
     },
     ja: {
       label: "日本語",
@@ -104,13 +107,17 @@ export default defineConfig({
               }
             ]
           }
-        ]
+        ],
+        darkModeSwitchLabel: "テーマ"
       }
     },
     "zh-hans": {
       label: "简体中文",
       lang: "zh-hans",
-      themeConfig: { nav: [{ text: "首页", link: "/zh-hans" }] }
+      themeConfig: {
+        nav: [{ text: "首页", link: "/zh-hans" }],
+        darkModeSwitchLabel: "外观"
+      }
     },
     root: {
       label: "한국어",
@@ -262,7 +269,8 @@ export default defineConfig({
               }
             ]
           }
-        ]
+        ],
+        darkModeSwitchLabel: "테마"
       }
     }
   },

--- a/fundamentals/bundling/.vitepress/config.mts
+++ b/fundamentals/bundling/.vitepress/config.mts
@@ -19,17 +19,26 @@ export default defineConfig({
     en: {
       label: "English",
       lang: "en",
-      themeConfig: { nav: [{ text: "Home", link: "/en/" }] }
+      themeConfig: {
+        nav: [{ text: "Home", link: "/en/" }],
+        darkModeSwitchLabel: "Appearance"
+      }
     },
     ja: {
       label: "日本語",
       lang: "ja",
-      themeConfig: { nav: [{ text: "ホーム", link: "/ja" }] }
+      themeConfig: {
+        nav: [{ text: "ホーム", link: "/ja" }],
+        darkModeSwitchLabel: "テーマ"
+      }
     },
     "zh-hans": {
       label: "简体中文",
       lang: "zh-hans",
-      themeConfig: { nav: [{ text: "首页", link: "/zh-hans" }] }
+      themeConfig: {
+        nav: [{ text: "首页", link: "/zh-hans" }],
+        darkModeSwitchLabel: "外观"
+      }
     },
     root: {
       label: "한국어",
@@ -181,7 +190,8 @@ export default defineConfig({
           prev: "이전 페이지",
           next: "다음 페이지"
         },
-        lastUpdated: { text: "마지막 업데이트" }
+        lastUpdated: { text: "마지막 업데이트" },
+        darkModeSwitchLabel: "테마"
       }
     }
   },
@@ -217,7 +227,7 @@ export default defineConfig({
       ]
     },
     ssr: {
-      noExternal: ['vitepress-plugin-tabs']
+      noExternal: ["vitepress-plugin-tabs"]
     }
   }
 });

--- a/fundamentals/code-quality/.vitepress/en.mts
+++ b/fundamentals/code-quality/.vitepress/en.mts
@@ -12,7 +12,8 @@ export const en = defineConfig({
       pattern:
         "https://github.com/toss/frontend-fundamentals/edit/main/fundamentals/code-quality/:path"
     },
-    sidebar: sidebar()
+    sidebar: sidebar(),
+    darkModeSwitchLabel: "Appearance"
   }
 });
 

--- a/fundamentals/code-quality/.vitepress/ja.mts
+++ b/fundamentals/code-quality/.vitepress/ja.mts
@@ -29,7 +29,8 @@ export const ja = defineConfig({
         link: "https://github.com/toss/frontend-fundamentals"
       }
     ],
-    sidebar: sidebar()
+    sidebar: sidebar(),
+    darkModeSwitchLabel: "テーマ"
   }
 });
 

--- a/fundamentals/code-quality/.vitepress/ko.mts
+++ b/fundamentals/code-quality/.vitepress/ko.mts
@@ -23,7 +23,8 @@ export const ko = defineConfig({
     lastUpdated: {
       text: "마지막 업데이트"
     },
-    sidebar: sidebar()
+    sidebar: sidebar(),
+    darkModeSwitchLabel: "테마"
   }
 });
 

--- a/fundamentals/code-quality/.vitepress/zhHans.mts
+++ b/fundamentals/code-quality/.vitepress/zhHans.mts
@@ -23,7 +23,8 @@ export const zhHans = defineConfig({
     lastUpdated: {
       text: "最后更新"
     },
-    sidebar: sidebar()
+    sidebar: sidebar(),
+    darkModeSwitchLabel: "外观"
   }
 });
 

--- a/fundamentals/debug/.vitepress/config.mts
+++ b/fundamentals/debug/.vitepress/config.mts
@@ -20,17 +20,26 @@ export default defineConfig({
     en: {
       label: "English",
       lang: "en",
-      themeConfig: { nav: [{ text: "Home", link: "/en/" }] }
+      themeConfig: {
+        nav: [{ text: "Home", link: "/en/" }],
+        darkModeSwitchLabel: "Appearance"
+      }
     },
     ja: {
       label: "日本語",
       lang: "ja",
-      themeConfig: { nav: [{ text: "ホーム", link: "/ja/" }] }
+      themeConfig: {
+        nav: [{ text: "ホーム", link: "/ja/" }],
+        darkModeSwitchLabel: "テーマ"
+      }
     },
     "zh-hans": {
       label: "简体中文",
       lang: "zh-hans",
-      themeConfig: { nav: [{ text: "首页", link: "/zh-hans" }] }
+      themeConfig: {
+        nav: [{ text: "首页", link: "/zh-hans" }],
+        darkModeSwitchLabel: "外观"
+      }
     },
     root: {
       label: "한국어",
@@ -165,7 +174,8 @@ export default defineConfig({
                   {
                     text: "React Query 사용 중 반환 타입 단언 오류",
                     link: "/pages/contribute/typescript/react_query_refetch_typescript.md"
-                  }                ]
+                  }
+                ]
               },
               {
                 text: "react",
@@ -250,10 +260,10 @@ export default defineConfig({
                 ]
               },
               {
-                text:"package",
-                items:[
+                text: "package",
+                items: [
                   {
-                    text:"Radix UI Dialog 내 Select 컴포넌트 ESC 키 충돌 버그 사례",
+                    text: "Radix UI Dialog 내 Select 컴포넌트 ESC 키 충돌 버그 사례",
                     link: "/pages/contribute/package/radix_ui_dialog_select_esc.md"
                   }
                 ]
@@ -270,7 +280,8 @@ export default defineConfig({
               { text: "기여하기 탬플릿", link: "/pages/contribute/template.md" }
             ]
           }
-        ]
+        ],
+        darkModeSwitchLabel: "테마"
       }
     }
   },


### PR DESCRIPTION
## 📝 Key Changes

## Summary
Adds localized `darkModeSwitchLabel` to each language configuration file.

## Changes
- Added `darkModeSwitchLabel` to Korean, Japanese, and Chinese locale configs
- Mobile navigation now displays the theme toggle label in the user's selected language

## issues
- https://github.com/toss/frontend-fundamentals/issues/830

## 🖼️ Before and After Comparison

|**Before**|**After**|
|:-:|:-:|
|<img width="615" height="342" alt="image" src="https://github.com/user-attachments/assets/1c5d8f0b-6aa5-4e7f-ab2c-e634b8aebb40" />|<img width="583" height="264" alt="image" src="https://github.com/user-attachments/assets/83209dad-4d16-4a3e-87be-f4870eb30c59" />|