### PR TITLE
fix: marketplace.json을 최신 Claude Code 스키마에 맞게 수정

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,8 +1,18 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "toss",
+  "owner": {
+    "name": "Toss"
+  },
   "plugins": [
     {
       "name": "frontend-fundamentals",
-      "path": "./frontend-fundamentals-plugin"
+      "source": "./frontend-fundamentals-plugin",
+      "description": "Frontend development best practices: code quality principles (readability, predictability, cohesion, coupling) and accessibility guidelines by Toss",
+      "version": "1.0.0",
+      "author": {
+        "name": "Toss"
+      }
     }
   ]
 }


### PR DESCRIPTION
## 문제

현재 `.claude-plugin/marketplace.json` 파일이 최신 Claude Code 플러그인 마켓플레이스 스키마에 맞지 않아,
플러그인 설치 시 아래와 같은 에러가 발생합니다.

```
/plugin marketplace add toss/frontend-fundamentals

Error: Failed to parse marketplace file:
  name: Invalid input: expected string, received undefined
  owner: Invalid input: expected object, received undefined
  plugins.0.source: Invalid input
  plugins.0: Unrecognized key: "path"
```

## 원인

플러그인이 처음 추가된 시점(#814, 2026-02-20) 이후 Claude Code의 마켓플레이스 스키마가 변경되었습니다.
현재 공식 문서에 따르면 다음 필드들이 필수로 요구됩니다:

| 필드 | 타입 | 설명 |
|------|------|------|
| `name` | string | 마켓플레이스 식별자 (kebab-case) |
| `owner` | object | 마켓플레이스 관리자 정보 (`name` 필수) |
| `plugins[].source` | string | 플러그인 소스 경로 (기존 `path`는 더 이상 인식되지 않음) |

공식 문서: https://code.claude.com/docs/en/plugin-marketplaces

## 변경 사항

```diff
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "toss",
+  "owner": {
+    "name": "Toss"
+  },
   "plugins": [
     {
       "name": "frontend-fundamentals",
-      "path": "./frontend-fundamentals-plugin"
+      "source": "./frontend-fundamentals-plugin",
+      "description": "Frontend development best practices: ...",
+      "version": "1.0.0",
+      "author": {
+        "name": "Toss"
+      }
     }
   ]
 }
```

- 필수 필드 `name`, `owner` 추가
- `path` → `source`로 키 이름 변경 (현행 스키마 기준)
- 플러그인 `description`, `version`, `author` 추가 (마켓플레이스 검색 및 표시용)

## 설치 방법

이 변경이 반영된 이후 아래와 같이 플러그인을 설치할 수 있습니다:

**Step 1.** 마켓플레이스 추가
```bash
/plugin marketplace add toss/frontend-fundamentals
```

**Step 2.** 플러그인 설치
```bash
/plugin install frontend-fundamentals@toss
```

**Step 3.** 코드 리뷰 실행
```bash
/frontend-fundamentals:review
```