### PR TITLE
fix(OneNavigation): width 1024px 이하에서 data-tooltip이 버튼을 가리는 현상 개선

### DIFF
--- a/fundamentals/shared/components/styles/OneNavigation.css
+++ b/fundamentals/shared/components/styles/OneNavigation.css
@@ -141,4 +141,15 @@
     height: 2px;
     width: calc(100% - 16px);
   }
+
+  .nav-item[data-tooltip]::after {
+    left: 50%;
+    top: auto;
+    bottom: calc(100% + 8px);
+    transform: translateX(-50%);
+  }
+
+  .nav-item[data-tooltip]:hover::after {
+    left: 50%;
+  }
 }


### PR DESCRIPTION
## 📝 Key Changes

- Closes #858
- data-tooltip이 버튼을 가려서 클릭할 수 없는 현상을 css에서 `max-width:1024px`일때, data-tooltip의 위치 값을 조정해서 해결했습니다.

## 🖼️ Before and After Comparison

<!-- Attach screenshots or a GIF showing the before and after changes. -->

|**Before**|**After**|
|:-:|:-:|
|<img width="944" height="54" alt="image" src="https://github.com/user-attachments/assets/d3a5a0d8-dab2-4eeb-8213-08214e1b9865" />|<img width="944" height="86" alt="image" src="https://github.com/user-attachments/assets/65be8d5c-ccae-42a2-a720-0ed6a0076de9" />|
